### PR TITLE
OpenForm refactor and cleanup

### DIFF
--- a/app/controllers/OpenForm.scala
+++ b/app/controllers/OpenForm.scala
@@ -15,7 +15,7 @@ class OpenForm(dynamo: DB, kong: Kong, val messagesApi: MessagesApi) extends Con
   import OpenForm._
   import Forms.OpenCreateKeyFormData
 
-  private val openLogic = new OpenFormLogic(dynamo, kong)
+  private val logic = new OpenFormLogic(dynamo, kong)
 
   def createKeyPage = Action { implicit request =>
     Ok(views.html.openCreateKey(createKeyForm))
@@ -27,7 +27,7 @@ class OpenForm(dynamo: DB, kong: Kong, val messagesApi: MessagesApi) extends Con
     }
 
     def handleValidForm(formData: OpenCreateKeyFormData): Future[Result] = {
-      openLogic.createUser(formData) map { consumerKey =>
+      logic.createUser(formData) map { consumerKey =>
         Redirect(routes.OpenForm.showKey(consumerKey))
       } recover {
         case ConflictFailure(errorMessage) => Conflict(views.html.openCreateKey(createKeyForm.fill(formData), error = Some(errorMessage)))

--- a/app/logic/OpenFormLogic.scala
+++ b/app/logic/OpenFormLogic.scala
@@ -18,7 +18,7 @@ class OpenFormLogic(dynamo: DB, kong: Kong) {
    * The key will be randomly generated, the tier is Developer
    * and the default rate limits are being used.
    *
-   * @return a Future of the newly created Kong consumer's ID
+   * @return a Future of the newly created Kong consumer's key
    */
 
   def createUser(form: OpenCreateKeyFormData): Future[String] = {

--- a/app/logic/OpenFormLogic.scala
+++ b/app/logic/OpenFormLogic.scala
@@ -1,8 +1,8 @@
 package logic
 
-import controllers.Forms.{ OpenCreateKeyFormData, CreateKeyFormData, CreateUserFormData, EditKeyFormData }
+import controllers.Forms.OpenCreateKeyFormData
 import kong.Kong
-import kong.Kong.{ ConflictFailure, Happy }
+import kong.Kong.ConflictFailure
 import models._
 import play.api.Logger
 import store.DB
@@ -20,6 +20,7 @@ class OpenFormLogic(dynamo: DB, kong: Kong) {
    *
    * @return a Future of the newly created Kong consumer's ID
    */
+
   def createUser(form: OpenCreateKeyFormData): Future[String] = {
     def saveUserAndKeyOnDB(consumer: ConsumerCreationResult, formData: OpenCreateKeyFormData): Unit = {
       Logger.info(s"OpenFormLogic: Creating user with name ${form.name}")
@@ -30,15 +31,14 @@ class OpenFormLogic(dynamo: DB, kong: Kong) {
       dynamo.saveKey(newKongKey)
     }
 
-    val user = dynamo.getUserWithEmail(form.email)
-    Logger.info(s"OpenFormLogic: Check if user with email ${form.email} already exists: ${user.isDefined}")
-    if (user.isDefined)
-      Future.failed(ConflictFailure("Email already taken. You cannot have more than one key associated with an email."))
-    else {
-      kong.createConsumerAndKey(Developer, Developer.rateLimit, key = None) map {
-        consumer =>
-          saveUserAndKeyOnDB(consumer, form)
-          consumer.id
+    dynamo.getUserWithEmail(form.email) match {
+      case Some(a) => Future.failed(ConflictFailure("Email already taken."))
+      case None => {
+        kong.createConsumerAndKey(Developer, Developer.rateLimit, key = None) map {
+          consumer =>
+            saveUserAndKeyOnDB(consumer, form)
+            consumer.key
+        }
       }
     }
   }

--- a/app/store/Dynamo.scala
+++ b/app/store/Dynamo.scala
@@ -26,8 +26,6 @@ trait DB {
 
   def getKeys(direction: String, range: Option[String]): ResultsPage[BonoboInfo]
 
-  def getKeyWithUserId(bonoboId: String): Option[KongKey]
-
   def getKeyWithValue(key: String): Option[KongKey]
 
   def getKeysWithUserId(id: String): List[KongKey]
@@ -133,18 +131,6 @@ class Dynamo(db: DynamoDB, usersTable: String, keysTable: String) extends DB {
     }
   }
 
-  def getKeyWithUserId(bonoboId: String): Option[KongKey] = {
-    val keyQuery = new QuerySpec()
-      .withKeyConditionExpression("hashkey = :h")
-      .withFilterExpression("bonoboId = :i")
-      .withValueMap(new ValueMap().withString(":i", bonoboId).withString(":h", "hashkey"))
-      .withMaxResultSize(1)
-      .withScanIndexForward(false)
-    val resultKey = KongTable.query(keyQuery).asScala.toList.map(fromKongItem).headOption
-    Logger.info(s"DynamoDB: Key for user with id $bonoboId is $resultKey")
-    resultKey
-  }
-
   def getKeyWithValue(keyValue: String): Option[KongKey] = {
     val query = new QuerySpec()
       .withConsistentRead(true)
@@ -173,7 +159,7 @@ class Dynamo(db: DynamoDB, usersTable: String, keysTable: String) extends DB {
 
   private def getKeysForUsers(users: List[BonoboUser]): List[KongKey] = {
     users.flatMap {
-      user => getKeyWithUserId(user.bonoboId)
+      user => getKeysWithUserId(user.bonoboId)
     }
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -19,7 +19,7 @@ POST        /user/:id/edit             controllers.Application.editUser(id: Stri
 
 GET         /create                    controllers.OpenForm.createKeyPage
 POST        /create                    controllers.OpenForm.createKey
-GET         /show                      controllers.OpenForm.showKey(userId: String)
+GET         /show                      controllers.OpenForm.showKey(key: String)
 
 GET         /healthcheck               controllers.Application.healthcheck
 


### PR DESCRIPTION
I modified `createUser` to return a key instead of a userId. This has the following advantages:

* code is shorter and saves a db query
* `dynamo.getKeyWithUserId` becomes useless (we already had `getKeysWithUserId` btw)
* the URL after a user has been created through OpenForm is now `?key=<key>` instead of `?userId=<userId>`, which is slightly better since we don't disclose internal information.