### PR TITLE
Migrate endpoint

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -82,8 +82,10 @@ trait ControllersComponent { self: BuiltInComponents with NingWSComponents with 
 
   val developerFormController = new DeveloperForm(dynamo, kong, awsEmail, messagesApi)
   val commercialFormController = new CommercialForm(dynamo, kong, awsEmail, messagesApi)
+  val migrationController = new Migration(dynamo, kong)
+
   val assets = new controllers.Assets(httpErrorHandler)
-  val router: Router = new Routes(httpErrorHandler, appController, developerFormController, commercialFormController, authController, assets)
+  val router: Router = new Routes(httpErrorHandler, appController, developerFormController, commercialFormController, authController, migrationController, assets)
 }
 
 class AppComponents(context: Context)

--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -4,7 +4,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsyncClient
-import controllers.{ CommercialForm, DeveloperForm, Application, Auth }
+import controllers._
 import com.gu.googleauth.GoogleAuthConfig
 import email.{ MailClient, AwsEmailClient }
 import kong.{ Kong, KongClient }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -232,7 +232,7 @@ object Application {
       "productUrl" -> nonEmptyText,
       "requestsPerDay" -> number,
       "requestsPerMinute" -> number,
-      "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withName(tier).get, (tier: Tier) => tier.toString),
+      "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withNameOption(tier).get, (tier: Tier) => tier.toString),
       "defaultRequests" -> boolean,
       "status" -> nonEmptyText
     )(EditKeyFormData.apply)(EditKeyFormData.unapply) verifying ("The number of requests per day is smaller than the number of requests per minute.", data => data.validateRequests)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -202,7 +202,7 @@ object Application {
       "companyUrl" -> nonEmptyText,
       "productName" -> nonEmptyText,
       "productUrl" -> nonEmptyText,
-      "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withName(tier).get, (tier: Tier) => tier.toString),
+      "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withNameOption(tier).get, (tier: Tier) => tier.toString),
       "key" -> optional(text.verifying(invalidKeyMessage, key => keyRegexPattern.matcher(key).matches()))
     )(CreateUserFormData.apply)(CreateUserFormData.unapply)
   )
@@ -219,7 +219,7 @@ object Application {
   val createKeyForm: Form[CreateKeyFormData] = Form(
     mapping(
       "key" -> optional(text.verifying(invalidKeyMessage, key => keyRegexPattern.matcher(key).matches())),
-      "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withName(tier).get, (tier: Tier) => tier.toString),
+      "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withNameOption(tier).get, (tier: Tier) => tier.toString),
       "productName" -> nonEmptyText,
       "productUrl" -> nonEmptyText
     )(CreateKeyFormData.apply)(CreateKeyFormData.unapply)

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -36,7 +36,7 @@ class Migration(dynamo: DB, kong: Kong) extends Controller {
   private def handleUserAndKeys(bonoboUser: BonoboUser, masheryKeys: List[MasheryKey]): Future[List[Unit]] = {
     dynamo.getUserWithEmail(bonoboUser.email) match {
       case Some(user) => {
-        Logger.warn(s"Migration: Email already taken when creating user with name ${bonoboUser.name} and keys with value ${masheryKeys.head.key}")
+        Logger.warn(s"Migration: Email already taken when creating user with name ${bonoboUser.name} and keys ${masheryKeys.map(_.key)}")
         Future.failed(ConflictFailure("Email already taken. You cannot have two users with the same email."))
       }
       case None => {

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import controllers.Forms.CreateKeyFormData
 import kong.Kong
 import kong.Kong.ConflictFailure
 import models._
@@ -25,48 +26,41 @@ class Migration(dynamo: DB, kong: Kong) extends Controller {
   private def handleMasheryUser(user: MasheryUser): Future[Unit] = {
     val bonoboId = java.util.UUID.randomUUID().toString
     val additionalInfo = AdditionalUserInfo(user.createdAt, MasheryRegistration)
-    val bonoboUser = BonoboUser(bonoboId, user.email, user.name, user.productName, user.productUrl, user.companyName, user.companyUrl, additionalInfo)
+    val bonoboUser = BonoboUser(bonoboId, user.email, user.name, user.companyName, user.companyUrl, additionalInfo)
+    //TODO: Check for empty fields
+
     createUserAndKeys(bonoboUser, user.keys)
   }
 
   private def createUserAndKeys(bonoboUser: BonoboUser, masheryKeys: List[MasheryKey]): Future[Unit] = {
-    Logger.info(s"Migration: Creating user with name ${bonoboUser.name} and keys $masheryKeys")
+    Logger.info(s"Migration: Creating user $bonoboUser with keys $masheryKeys")
 
     dynamo.getUserWithEmail(bonoboUser.email) match {
       case Some(user) => {
         Logger.warn(s"Migration: Email already taken when creating user with name ${bonoboUser.name} and key with value ${masheryKeys.head.key}")
-        masheryKeys.drop(1).foreach(createKey(bonoboUser.bonoboId, _))
-        Future.successful(())
+        Future.failed(ConflictFailure("Email already taken. You cannot have two users with the same email."))
       }
       case None => {
-        checkingIfKeyAlreadyTaken(masheryKeys.head.key)(createConsumer(bonoboUser, masheryKeys.head))
+        dynamo.saveUser(bonoboUser)
+        masheryKeys.map(key => createKey(bonoboUser, key))
+        Future.successful(())
       }
     }
   }
 
-  private def createConsumer(user: BonoboUser, key: MasheryKey): Future[Unit] = {
-    Logger.info(s"Migration: Creating consumer for user with id ${user.bonoboId}")
-    val rateLimits: RateLimits = key.tier.rateLimit
-    kong.createConsumerAndKey(key.tier, rateLimits, Some(key.key)) map {
-      consumer =>
-        dynamo.saveUser(user)
-        saveKeyOnDB(user.bonoboId, consumer, rateLimits, key.tier)
-    }
-  }
-
-  private def createKey(userId: String, key: MasheryKey): Future[Unit] = {
-    Logger.info(s"Migration: Creating key for user with id $userId")
+  private def createKey(bonoboUser: BonoboUser, key: MasheryKey): Future[Unit] = {
+    Logger.info(s"Migration: Creating key for user $bonoboUser")
     def createConsumerAndKey: Future[Unit] = {
       val rateLimits: RateLimits = key.tier.rateLimit
       kong.createConsumerAndKey(key.tier, rateLimits, Some(key.key)) map {
-        consumer => saveKeyOnDB(userId, consumer, rateLimits, key.tier)
+        consumer => saveKeyOnDB(bonoboUser.bonoboId, consumer, rateLimits, key.tier, key.productName, key.productUrl)
       }
     }
     checkingIfKeyAlreadyTaken(key.key)(createConsumerAndKey)
   }
 
-  private def saveKeyOnDB(userId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier): Unit = {
-    val newKongKey = KongKey(userId, consumer, rateLimits, tier)
+  private def saveKeyOnDB(userId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier, productName: String, productUrl: String): Unit = {
+    val newKongKey = KongKey(userId, consumer, rateLimits, tier, productName, productUrl)
     dynamo.saveKey(newKongKey)
   }
 

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -3,75 +3,66 @@ package controllers
 import kong.Kong
 import kong.Kong.ConflictFailure
 import models._
-import org.joda.time.DateTime
 import play.api.Logger
-import play.api.libs.json.{ Json, JsError, JsSuccess, JsValue }
+import play.api.libs.json.{ JsError, JsSuccess }
 import play.api.mvc._
 import store.DB
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.Future
 
-case class MasheryUser(
-  name: String,
-  email: String,
-  productName: String,
-  productUrl: String,
-  companyName: String,
-  companyUrl: Option[String],
-  createdAt: DateTime,
-  keys: List[MasheryKey])
-
-object MasheryKey {
-  implicit val keyRead = Json.reads[MasheryKey]
-}
-
-object MasheryUser {
-  implicit val userRead = Json.reads[MasheryUser]
-}
-
-case class MasheryKey(
-  key: String,
-  requestsPerDay: Int,
-  requestsPerMinute: Int,
-  tier: Tier,
-  status: String,
-  createdAt: DateTime)
-
 class Migration(dynamo: DB, kong: Kong) extends Controller {
   def migrate = Action(parse.json) { implicit request =>
     request.body.validate[List[MasheryUser]] match {
-      case JsSuccess(j, _) => j.map(handleValidJson)
-      case JsError(errorMessage) => Logger.warn(s"Error when parsing json: $errorMessage")
+      case JsSuccess(j, _) => {
+        j.foreach(handleMasheryUser)
+      }
+      case JsError(errorMessage) => Logger.warn(s"Migration: Error when parsing json: $errorMessage")
     }
     Ok("OK")
   }
 
-  private def handleValidJson(user: MasheryUser): Unit = {
+  private def handleMasheryUser(user: MasheryUser): Future[Unit] = {
     val bonoboId = java.util.UUID.randomUUID().toString
     val additionalInfo = AdditionalUserInfo(user.createdAt, MasheryRegistration)
     val bonoboUser = BonoboUser(bonoboId, user.email, user.name, user.productName, user.productUrl, user.companyName, user.companyUrl, additionalInfo)
-    user.keys.map(createUserAndKey(bonoboUser, _))
+    createUserAndKeys(bonoboUser, user.keys)
   }
 
-  private def createUserAndKey(bonoboUser: BonoboUser, masheryKey: MasheryKey): Future[String] = {
-    Logger.info(s"Migration: Creating user with name ${bonoboUser.name}")
-
-    def createConsumer: Future[String] = {
-      val rateLimits: RateLimits = masheryKey.tier.rateLimit
-      kong.createConsumerAndKey(masheryKey.tier, rateLimits, Some(masheryKey.key)) map {
-        consumer =>
-          dynamo.saveUser(bonoboUser)
-          val kongKey = KongKey(bonoboUser.bonoboId, consumer.id, masheryKey.key, masheryKey.requestsPerDay, masheryKey.requestsPerMinute, masheryKey.tier, masheryKey.status, masheryKey.createdAt, masheryKey.createdAt.toString)
-          dynamo.saveKey(kongKey)
-          consumer.id
-      }
-    }
+  private def createUserAndKeys(bonoboUser: BonoboUser, masheryKeys: List[MasheryKey]): Future[Unit] = {
+    Logger.info(s"Migration: Creating user with name ${bonoboUser.name} and keys $masheryKeys")
 
     dynamo.getUserWithEmail(bonoboUser.email) match {
-      case Some(user) => Future.failed(ConflictFailure("Email already taken. You cannot have two users with the same email."))
-      case None => checkingIfKeyAlreadyTaken(masheryKey.key)(createConsumer)
+      case Some(user) => {
+        Logger.warn(s"Migration: Email already taken when creating user with name ${bonoboUser.name} and key with value ${masheryKeys.head.key}")
+        masheryKeys.drop(1).foreach(createKey(bonoboUser.bonoboId, _))
+        Future.successful(())
+      }
+      case None => {
+        checkingIfKeyAlreadyTaken(masheryKeys.head.key)(createConsumer(bonoboUser, masheryKeys.head))
+      }
     }
+  }
+
+  private def createConsumer(user: BonoboUser, key: MasheryKey): Future[Unit] = {
+    Logger.info(s"Migration: Creating consumer for user with id ${user.bonoboId}")
+    val rateLimits: RateLimits = key.tier.rateLimit
+    kong.createConsumerAndKey(key.tier, rateLimits, Some(key.key)) map {
+      consumer =>
+        dynamo.saveUser(user)
+        saveKeyOnDB(user.bonoboId, consumer, rateLimits, key.tier)
+    }
+  }
+
+  private def createKey(userId: String, key: MasheryKey): Future[Unit] = {
+    Logger.info(s"Migration: Creating key for user with id $userId")
+    def createConsumerAndKey: Future[Unit] = {
+      val rateLimits: RateLimits = key.tier.rateLimit
+      kong.createConsumerAndKey(key.tier, rateLimits, Some(key.key)) map {
+        consumer => saveKeyOnDB(userId, consumer, rateLimits, key.tier)
+      }
+    }
+    checkingIfKeyAlreadyTaken(key.key)(createConsumerAndKey)
   }
 
   private def saveKeyOnDB(userId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier): Unit = {
@@ -80,7 +71,8 @@ class Migration(dynamo: DB, kong: Kong) extends Controller {
   }
 
   private def checkingIfKeyAlreadyTaken[A](key: String)(f: => Future[A]): Future[A] =
-    if (dynamo.getKeyWithValue(key).isDefined)
+    if (dynamo.getKeyWithValue(key).isDefined) {
+      Logger.warn(s"Migration: Key $key already taken")
       Future.failed(ConflictFailure("Key already taken."))
-    else f
+    } else f
 }

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -1,0 +1,86 @@
+package controllers
+
+import kong.Kong
+import kong.Kong.ConflictFailure
+import models._
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.{ Json, JsError, JsSuccess, JsValue }
+import play.api.mvc._
+import store.DB
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
+
+case class MasheryUser(
+  name: String,
+  email: String,
+  productName: String,
+  productUrl: String,
+  companyName: String,
+  companyUrl: Option[String],
+  createdAt: DateTime,
+  keys: List[MasheryKey])
+
+object MasheryKey {
+  implicit val keyRead = Json.reads[MasheryKey]
+}
+
+object MasheryUser {
+  implicit val userRead = Json.reads[MasheryUser]
+}
+
+case class MasheryKey(
+  key: String,
+  requestsPerDay: Int,
+  requestsPerMinute: Int,
+  tier: Tier,
+  status: String,
+  createdAt: DateTime)
+
+class Migration(dynamo: DB, kong: Kong) extends Controller {
+  def migrate = Action(parse.json) { implicit request =>
+    request.body.validate[List[MasheryUser]] match {
+      case JsSuccess(j, _) => j.map(handleValidJson)
+      case JsError(errorMessage) => Logger.warn(s"Error when parsing json: $errorMessage")
+    }
+    Ok("OK")
+  }
+
+  private def handleValidJson(user: MasheryUser): Unit = {
+    val bonoboId = java.util.UUID.randomUUID().toString
+    val additionalInfo = AdditionalUserInfo(user.createdAt, MasheryRegistration)
+    val bonoboUser = BonoboUser(bonoboId, user.email, user.name, user.productName, user.productUrl, user.companyName, user.companyUrl, additionalInfo)
+    user.keys.map(createUserAndKey(bonoboUser, _))
+  }
+
+  private def createUserAndKey(bonoboUser: BonoboUser, masheryKey: MasheryKey): Future[String] = {
+    Logger.info(s"Migration: Creating user with name ${bonoboUser.name}")
+
+    def createConsumer: Future[String] = {
+      val rateLimits: RateLimits = masheryKey.tier.rateLimit
+      kong.createConsumerAndKey(masheryKey.tier, rateLimits, Some(masheryKey.key)) map {
+        consumer =>
+          dynamo.saveUser(bonoboUser)
+          val kongKey = KongKey(bonoboUser.bonoboId, consumer.id, masheryKey.key, masheryKey.requestsPerDay, masheryKey.requestsPerMinute, masheryKey.tier, masheryKey.status, masheryKey.createdAt, masheryKey.createdAt.toString)
+          dynamo.saveKey(kongKey)
+          consumer.id
+      }
+    }
+
+    dynamo.getUserWithEmail(bonoboUser.email) match {
+      case Some(user) => Future.failed(ConflictFailure("Email already taken. You cannot have two users with the same email."))
+      case None => checkingIfKeyAlreadyTaken(masheryKey.key)(createConsumer)
+    }
+  }
+
+  private def saveKeyOnDB(userId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier): Unit = {
+    val newKongKey = KongKey(userId, consumer, rateLimits, tier)
+    dynamo.saveKey(newKongKey)
+  }
+
+  private def checkingIfKeyAlreadyTaken[A](key: String)(f: => Future[A]): Future[A] =
+    if (dynamo.getKeyWithValue(key).isDefined)
+      Future.failed(ConflictFailure("Key already taken."))
+    else f
+}

--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -39,7 +39,6 @@ object Kong {
 
   object KongListConsumerKeysResponse {
     implicit val keyRead = Json.reads[KongListConsumerKeysResponse]
-
   }
 
   case class KongPluginConfig(id: String)

--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -116,7 +116,7 @@ class KongClient(ws: WSClient, serverUrl: String, apiName: String) extends Kong 
       response =>
         response.status match {
           case 201 => success(s"Kong: Success when creating the new key $key", key)
-          case 409 => conflictFail(s"Key $key already taken - try using a different value")
+          case 409 => conflictFail(s"Kong: Key $key already taken - try using a different value")
           case other =>
             genericFail(s"Kong responded with status $other - ${response.body} when trying to create a key for consumer $consumerId")
         }

--- a/app/logic/CommercialFormLogic.scala
+++ b/app/logic/CommercialFormLogic.scala
@@ -2,12 +2,9 @@ package logic
 
 import controllers.Forms.CommercialRequestKeyFormData
 import kong.Kong
-import kong.Kong.ConflictFailure
-import models.{ Developer, KongKey, BonoboUser, ConsumerCreationResult }
+import models.BonoboUser
 import play.api.Logger
 import store.DB
-
-import scala.concurrent.Future
 
 class CommercialFormLogic(dynamo: DB, kong: Kong) {
 

--- a/app/logic/DeveloperFormLogic.scala
+++ b/app/logic/DeveloperFormLogic.scala
@@ -27,7 +27,7 @@ class DeveloperFormLogic(dynamo: DB, kong: Kong) {
       val newBonoboUser = BonoboUser(consumer.id, formData)
       dynamo.saveUser(newBonoboUser)
 
-      val newKongKey = KongKey(consumer.id, consumer, Developer.rateLimit, Developer, formData.productName, formData.productUrl)
+      val newKongKey = KongKey(consumer.id, consumer, Tier.Developer.rateLimit, Tier.Developer, formData.productName, formData.productUrl)
       dynamo.saveKey(newKongKey)
     }
 

--- a/app/logic/DeveloperFormLogic.scala
+++ b/app/logic/DeveloperFormLogic.scala
@@ -34,7 +34,7 @@ class DeveloperFormLogic(dynamo: DB, kong: Kong) {
     dynamo.getUserWithEmail(form.email) match {
       case Some(a) => Future.failed(ConflictFailure("Email already taken."))
       case None => {
-        kong.createConsumerAndKey(Developer, Developer.rateLimit, key = None) map {
+        kong.createConsumerAndKey(Tier.Developer, Tier.Developer.rateLimit, key = None) map {
           consumer =>
             saveUserAndKeyOnDB(consumer, form)
             consumer.key

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -82,6 +82,10 @@ object KongKey {
     new KongKey(bonoboId, consumer.id, consumer.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, tier, Active, consumer.createdAt, productName, productUrl, uniqueRangeKey(consumer.createdAt))
   }
 
+  /* model used in the migration endpoint */
+  def apply(bonoboId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier, productName: String, productUrl: String, status: String, date: DateTime): KongKey = {
+    new KongKey(bonoboId, consumer.id, consumer.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, tier, status, date, productName, productUrl, uniqueRangeKey(consumer.createdAt))
+  }
 }
 
 /* model used for show all keys table */

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -2,6 +2,7 @@ package models
 
 import java.util.UUID
 import controllers.Forms._
+import enumeratum.{ PlayJsonEnum, Enum, EnumEntry }
 import org.joda.time.DateTime
 
 /* model used for saving the users on Bonobo */
@@ -91,37 +92,33 @@ case class ConsumerCreationResult(id: String, createdAt: DateTime, key: String)
 
 case class RateLimits(requestsPerMinute: Int, requestsPerDay: Int)
 
-sealed trait Tier {
+sealed trait Tier extends EnumEntry {
   def rateLimit: RateLimits
   def friendlyName: String
   def conciergeName: String
 }
 
-object Tier {
-  def withName(tier: String): Option[Tier] = tier match {
-    case "Developer" => Some(Developer)
-    case "RightsManaged" => Some(RightsManaged)
-    case "Internal" => Some(Internal)
-    case _ => None
+object Tier extends Enum[Tier] with PlayJsonEnum[Tier] {
+
+  val values = findValues
+
+  case object Developer extends Tier {
+    def rateLimit: RateLimits = RateLimits(720, 5000)
+    def friendlyName: String = "Developer"
+    def conciergeName: String = "developer"
+  }
+  case object RightsManaged extends Tier {
+    def rateLimit: RateLimits = RateLimits(720, 10000)
+    def friendlyName: String = "Rights managed"
+    def conciergeName: String = "rights-managed"
+  }
+  case object Internal extends Tier {
+    def rateLimit: RateLimits = RateLimits(720, 10000)
+    def friendlyName: String = "Internal"
+    def conciergeName: String = "internal"
   }
 
-  def isValid(tier: String): Boolean = withName(tier).isDefined
-}
-
-case object Developer extends Tier {
-  def rateLimit: RateLimits = RateLimits(720, 5000)
-  def friendlyName: String = "Developer"
-  def conciergeName: String = "developer"
-}
-case object RightsManaged extends Tier {
-  def rateLimit: RateLimits = RateLimits(720, 10000)
-  def friendlyName: String = "Rights managed"
-  def conciergeName: String = "rights-managed"
-}
-case object Internal extends Tier {
-  def rateLimit: RateLimits = RateLimits(720, 10000)
-  def friendlyName: String = "Internal"
-  def conciergeName: String = "internal"
+  def isValid(tier: String): Boolean = withNameOption(tier).isDefined
 }
 
 sealed trait RegistrationType {
@@ -133,6 +130,7 @@ object RegistrationType {
     case "Developer" => Some(DeveloperRegistration)
     case "Commercial" => Some(CommercialRegistration)
     case "Manual" => Some(ManualRegistration)
+    case "Mashery" => Some(MasheryRegistration)
     case _ => None
   }
 }
@@ -145,5 +143,8 @@ case object CommercialRegistration extends RegistrationType {
 }
 case object ManualRegistration extends RegistrationType {
   def friendlyName: String = "Manual"
+}
+case object MasheryRegistration extends RegistrationType {
+  def friendlyName: String = "Imported from Mashery"
 }
 

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -180,3 +180,28 @@ case class MasheryKey(
   tier: Tier,
   status: String,
   createdAt: DateTime)
+
+case class MigrationResult(successfullyManagedUsers: Int, successfullyManagedKeys: Int, userConflicts: List[EmailConflict], keyConflicts: List[KeyConflict])
+
+sealed trait MigrateUserResult
+case class MigratedUser(keyResults: List[MigrateKeyResult]) extends MigrateUserResult
+case class EmailConflict(email: String) extends MigrateUserResult
+
+sealed trait MigrateKeyResult
+case object MigratedKey extends MigrateKeyResult
+case class KeyConflict(key: String) extends MigrateKeyResult
+
+case object EmailConflict {
+  implicit val emailConflictWrites = Json.writes[EmailConflict]
+  implicit val emailConflictReads = Json.reads[EmailConflict]
+}
+
+case object KeyConflict {
+  implicit val keyConflictWrites = Json.writes[KeyConflict]
+  implicit val keyConflictReads = Json.reads[KeyConflict]
+}
+
+case object MigrationResult {
+  implicit val migrationResultWrites = Json.writes[MigrationResult]
+  implicit val migrationResultReads = Json.reads[MigrationResult]
+}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -162,12 +162,12 @@ case class MasheryUser(
   keys: List[MasheryKey])
 
 object MasheryKey {
-  implicit val dateReads = Reads.jodaDateReads("MMM dd yyyy HH:mm:ss")
+  implicit val dateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss'Z'")
   implicit val keyRead = Json.reads[MasheryKey]
 }
 
 object MasheryUser {
-  implicit val dateReads = Reads.jodaDateReads("MMM dd yyyy HH:mm:ss")
+  implicit val dateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss'Z'")
   implicit val userRead = Json.reads[MasheryUser]
 }
 

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 import controllers.Forms._
 import enumeratum.{ PlayJsonEnum, Enum, EnumEntry }
 import org.joda.time.DateTime
+import play.api.libs.json.{ Reads, Json }
 
 /* model used for saving the users on Bonobo */
 case class BonoboUser(
@@ -130,7 +131,7 @@ object RegistrationType {
     case "Developer" => Some(DeveloperRegistration)
     case "Commercial" => Some(CommercialRegistration)
     case "Manual" => Some(ManualRegistration)
-    case "Mashery" => Some(MasheryRegistration)
+    case "Imported from Mashery" => Some(MasheryRegistration)
     case _ => None
   }
 }
@@ -148,3 +149,30 @@ case object MasheryRegistration extends RegistrationType {
   def friendlyName: String = "Imported from Mashery"
 }
 
+case class MasheryUser(
+  name: String,
+  email: String,
+  productName: String,
+  productUrl: String,
+  companyName: String,
+  companyUrl: Option[String],
+  createdAt: DateTime,
+  keys: List[MasheryKey])
+
+object MasheryKey {
+  implicit val dateReads = Reads.jodaDateReads("MMM dd yyyy HH:mm:ss")
+  implicit val keyRead = Json.reads[MasheryKey]
+}
+
+object MasheryUser {
+  implicit val dateReads = Reads.jodaDateReads("MMM dd yyyy HH:mm:ss")
+  implicit val userRead = Json.reads[MasheryUser]
+}
+
+case class MasheryKey(
+  key: String,
+  requestsPerDay: Int,
+  requestsPerMinute: Int,
+  tier: Tier,
+  status: String,
+  createdAt: DateTime)

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import controllers.Forms._
 import enumeratum.{ PlayJsonEnum, Enum, EnumEntry }
 import org.joda.time.DateTime
-import play.api.libs.json.{ Reads, Json }
+import play.api.libs.json.{ Writes, Reads, Json }
 
 /* model used for saving the users on Bonobo */
 case class BonoboUser(
@@ -152,10 +152,8 @@ case object MasheryRegistration extends RegistrationType {
 case class MasheryUser(
   name: String,
   email: String,
-  productName: String,
-  productUrl: String,
   companyName: String,
-  companyUrl: Option[String],
+  companyUrl: String,
   createdAt: DateTime,
   keys: List[MasheryKey])
 
@@ -171,6 +169,8 @@ object MasheryUser {
 
 case class MasheryKey(
   key: String,
+  productName: String,
+  productUrl: String,
   requestsPerDay: Int,
   requestsPerMinute: Int,
   tier: Tier,

--- a/app/store/Dynamo.scala
+++ b/app/store/Dynamo.scala
@@ -3,6 +3,7 @@ package store
 import com.amazonaws.services.dynamodbv2.document.spec.{ QuerySpec, ScanSpec }
 import com.amazonaws.services.dynamodbv2.document.utils.{ NameMap, ValueMap }
 import com.amazonaws.services.dynamodbv2.document._
+import models.Tier.Developer
 import models._
 import org.joda.time.DateTime
 import play.api.Logger
@@ -282,7 +283,7 @@ object Dynamo {
 
   def fromKongItem(item: Item): KongKey = {
     def toTier(tier: String): Tier = {
-      Tier.withName(tier).getOrElse {
+      Tier.withNameOption(tier).getOrElse {
         Logger.warn(s"Invalid tier in DynamoDB: $tier")
         Developer
       }

--- a/app/views/createUser.scala.html
+++ b/app/views/createUser.scala.html
@@ -5,13 +5,13 @@
     <div class="row">
         <div class="col-md-6 col-md-offset-2 column">
             @b3.form(routes.Application.createUser) {
-                @b3.text( form("name"), '_label -> "Name *", 'placeholder -> "Name" )
-                @b3.email( form("email"), '_label -> "Email *", 'placeholder -> "example@mail.com" )
-                @b3.text( form("companyName"), '_label -> "Company name *", 'placeholder -> "Company name" )
+                @b3.text( form("name"), '_label -> "Name", 'placeholder -> "Name" )
+                @b3.email( form("email"), '_label -> "Email", 'placeholder -> "example@mail.com" )
+                @b3.text( form("companyName"), '_label -> "Company name", 'placeholder -> "Company name" )
                 @b3.text( form("companyUrl"), '_label -> "Company URL", 'placeholder -> "Company URL" )
-                @b3.text( form("productName"), '_label -> "Product name *", 'placeholder -> "Product name" )
-                @b3.text( form("productUrl"), '_label -> "Product URL *", 'placeholder -> "Product URL" )
-                @b3.select( form("tier"), options = Seq(Developer.toString -> Developer.friendlyName, RightsManaged.toString -> RightsManaged.friendlyName, Internal.toString -> Internal.friendlyName), '_label -> "Tier *" )
+                @b3.text( form("productName"), '_label -> "Product name", 'placeholder -> "Product name" )
+                @b3.text( form("productUrl"), '_label -> "Product URL", 'placeholder -> "Product URL" )
+                @b3.select( form("tier"), options = Seq(Tier.Developer.toString -> Tier.Developer.friendlyName, Tier.RightsManaged.toString -> Tier.RightsManaged.friendlyName, Tier.Internal.toString -> Tier.Internal.friendlyName), '_label -> "Tier *" )
                 @b3.text( form("key"), '_label -> "Key", 'placeholder -> "Insert custom key" )
                 @b3.submit('class -> "btn btn-primary"){ <span class="glyphicon glyphicon-ok"></span> Save }
             }

--- a/app/views/editKey.scala.html
+++ b/app/views/editKey.scala.html
@@ -10,7 +10,7 @@
             @b3.text( form("productUrl"), '_label -> "Product URL", 'placeholder -> "Product URL" )
             @b3.number( form("requestsPerDay"), '_label -> "Requests per day", 'placeholder -> "Requests per day", 'min -> "0" )
             @b3.number( form("requestsPerMinute"), '_label -> "Requests per minute", 'placeholder -> "Requests per minute", 'min -> "0" )
-            @b3.select( form("tier"), options = Seq(Developer.toString -> Developer.friendlyName, RightsManaged.toString -> RightsManaged.friendlyName, Internal.toString -> Internal.friendlyName), '_label -> "Tier" )
+            @b3.select( form("tier"), options = Seq(Tier.Developer.toString -> Tier.Developer.friendlyName, Tier.RightsManaged.toString -> Tier.RightsManaged.friendlyName, Tier.Internal.toString -> Tier.Internal.friendlyName), '_label -> "Tier" )
             @b3.checkbox( form("defaultRequests"), '_label -> "Use default rate limits" )
             @b3.select( form("status"), options = Seq(KongKey.Active -> "Active", KongKey.Inactive -> "Inactive"), '_label -> "Status" )
             @b3.free('_id -> "idFormGroup") {

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,9 @@ libraryDependencies ++= Seq(
   "com.gu" %% "play-googleauth" % "0.3.1",
   "org.scalatest" % "scalatest_2.11" % "2.2.5" % "it,test",
   "org.scalatestplus" % "play_2.11" % "1.4.0-M4" % "it,test",
-  "org.mockito" % "mockito-all" % "1.10.19" % "test"
+  "org.mockito" % "mockito-all" % "1.10.19" % "test",
+  "com.beachape" %% "enumeratum" % "1.3.2",
+  "com.beachape" %% "enumeratum-play-json" % "1.3.2"
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"

--- a/build.sbt
+++ b/build.sbt
@@ -39,4 +39,6 @@ scalariformSettings
 
 testOptions in Test += Tests.Argument("-oF")
 
+parallelExecution in IntegrationTest := false
+
 sourceDirectory in IntegrationTest <<= baseDirectory { base => base / "integration-test" }

--- a/conf/routes
+++ b/conf/routes
@@ -33,5 +33,8 @@ GET         /register/message          controllers.CommercialForm.requestMessage
 GET         /login                     controllers.Auth.login
 GET         /oauth2callback            controllers.Auth.oauth2Callback
 
+#Migrate data from Mashery
+POST        /migrate                   controllers.Migration.migrate
+
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file              controllers.Assets.versioned(path="/public", file: Asset)

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "Joe Bloggs",
+    "email": "test@migratemashery.com",
+    "companyName": "Company name",
+    "companyUrl": "http://company.com",
+    "productName": "Product name",
+    "productUrl": "http://product.com",
+    "createdAt": "Thu Nov 12 2015 14:29:48 GMT+0000 (GMT)",
+    "keys": [
+      {
+        "key": "some-key",
+        "createdAt": "Thu Nov 12 2015 14:29:48 GMT+0000 (GMT)",
+        "status": "active",
+        "tier": "developer",
+        "requestsPerDay": "1000",
+        "requestsPerMinute": "100"
+      },
+      {
+        "key": "some-other-key",
+        "createdAt": "Thu Nov 11 2015 14:29:48 GMT+0000 (GMT)",
+        "status": "active",
+        "tier": "developer",
+        "requestsPerDay": "1000",
+        "requestsPerMinute": "100"
+      }
+    ]
+  },
+  {
+    "name": "Joe Blogg",
+    "email": "test2@migratemashery.com",
+    "companyName": "Company name",
+    "companyUrl": "",
+    "productName": "Product name",
+    "productUrl": "http://product.com",
+    "createdAt": "Thu Nov 10 2015 17:29:48 GMT+0000 (GMT)",
+    "keys": [
+      {
+        "key": "some-key-2",
+        "createdAt": "Thu Nov 11 2015 14:30:48 GMT+0000 (GMT)",
+        "status": "active",
+        "tier": "internal",
+        "requestsPerDay": "1000",
+        "requestsPerMinute": "100"
+      },
+      {
+        "key": "some-other-key-2",
+        "createdAt": "Thu Nov 11 2015 14:29:48 GMT+0000 (GMT)",
+        "status": "active",
+        "tier": "developer",
+        "requestsPerDay": "1000",
+        "requestsPerMinute": "100"
+      }
+    ]
+  }
+]

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -1,15 +1,15 @@
 [
   {
-    "name": "First Migration",
+    "name": "First User",
     "email": "test@migratemashery.com",
-    "productName": "Product name",
-    "productUrl": "http://product.com",
     "companyName": "Company name",
     "companyUrl": "http://company.com",
     "createdAt": "Nov 12 2015 14:29:48",
     "keys": [
       {
         "key": "first-key-1",
+        "productName": "Product name",
+        "productUrl": "http://product.com",
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",
@@ -18,6 +18,8 @@
       },
       {
         "key": "first-key-2",
+        "productName": "Product name",
+        "productUrl": "http://product.com",
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",
@@ -27,16 +29,16 @@
     ]
   },
   {
-    "name": "Second Migration",
+    "name": "Second User",
     "email": "test2@migratemashery.com",
-    "productName": "Product name",
-    "productUrl": "http://product.com",
     "companyName": "Company name",
-    "companyUrl": "",
+    "companyUrl": "http://company.com",
     "createdAt": "Nov 10 2015 17:29:48",
     "keys": [
       {
         "key": "second-key-1",
+        "productName": "Product name",
+        "productUrl": "http://product.com",
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Internal",
@@ -45,6 +47,8 @@
       },
       {
         "key": "second-key-2",
+        "productName": "Product name",
+        "productUrl": "http://product.com",
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -74,5 +74,24 @@
     "companyUrl": "",
     "createdAt": "2015-11-09T14:29:48Z",
     "keys": []
+  },
+  {
+    "name": "Forth User",
+    "email": "test@migratemashery.com",
+    "companyName": "Company name",
+    "companyUrl": "",
+    "createdAt": "2015-11-09T14:29:48Z",
+    "keys": [
+      {
+        "key": "forth-key-1",
+        "productName": "Product name",
+        "productUrl": "http://product.com",
+        "requestsPerDay": 1000,
+        "requestsPerMinute": 100,
+        "tier": "Developer",
+        "status": "Inactive",
+        "createdAt": "2015-11-09T14:29:48Z"
+      }
+    ]
   }
 ]

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -3,7 +3,7 @@
     "name": "First User",
     "email": "test@migratemashery.com",
     "companyName": "Company name",
-    "companyUrl": "http://company.com",
+    "companyUrl": "",
     "createdAt": "Nov 12 2015 14:29:48",
     "keys": [
       {
@@ -13,7 +13,7 @@
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",
-        "status": "active",
+        "status": "Active",
         "createdAt": "Nov 12 2015 14:29:48"
       },
       {
@@ -23,7 +23,7 @@
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",
-        "status": "active",
+        "status": "Active",
         "createdAt": "Nov 11 2015 14:29:48"
       }
     ]
@@ -42,7 +42,7 @@
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Internal",
-        "status": "active",
+        "status": "Active",
         "createdAt": "Nov 11 2015 14:30:48"
       },
       {
@@ -52,7 +52,17 @@
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",
-        "status": "active",
+        "status": "Active",
+        "createdAt": "Nov 11 2015 14:29:48"
+      },
+      {
+        "key": "second-key-3",
+        "productName": "Product name",
+        "productUrl": "http://product.com",
+        "requestsPerDay": 1000,
+        "requestsPerMinute": 20,
+        "tier": "Developer",
+        "status": "Inactive",
         "createdAt": "Nov 11 2015 14:29:48"
       }
     ]

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -1,55 +1,55 @@
 [
   {
-    "name": "Joe Bloggs",
+    "name": "First Migration",
     "email": "test@migratemashery.com",
-    "companyName": "Company name",
-    "companyUrl": "http://company.com",
     "productName": "Product name",
     "productUrl": "http://product.com",
-    "createdAt": "Thu Nov 12 2015 14:29:48 GMT+0000 (GMT)",
+    "companyName": "Company name",
+    "companyUrl": "http://company.com",
+    "createdAt": "Nov 12 2015 14:29:48",
     "keys": [
       {
-        "key": "some-key",
-        "createdAt": "Thu Nov 12 2015 14:29:48 GMT+0000 (GMT)",
+        "key": "first-key-1",
+        "requestsPerDay": 1000,
+        "requestsPerMinute": 100,
+        "tier": "Developer",
         "status": "active",
-        "tier": "developer",
-        "requestsPerDay": "1000",
-        "requestsPerMinute": "100"
+        "createdAt": "Nov 12 2015 14:29:48"
       },
       {
-        "key": "some-other-key",
-        "createdAt": "Thu Nov 11 2015 14:29:48 GMT+0000 (GMT)",
+        "key": "first-key-2",
+        "requestsPerDay": 1000,
+        "requestsPerMinute": 100,
+        "tier": "Developer",
         "status": "active",
-        "tier": "developer",
-        "requestsPerDay": "1000",
-        "requestsPerMinute": "100"
+        "createdAt": "Nov 11 2015 14:29:48"
       }
     ]
   },
   {
-    "name": "Joe Blogg",
+    "name": "Second Migration",
     "email": "test2@migratemashery.com",
-    "companyName": "Company name",
-    "companyUrl": "",
     "productName": "Product name",
     "productUrl": "http://product.com",
-    "createdAt": "Thu Nov 10 2015 17:29:48 GMT+0000 (GMT)",
+    "companyName": "Company name",
+    "companyUrl": "",
+    "createdAt": "Nov 10 2015 17:29:48",
     "keys": [
       {
-        "key": "some-key-2",
-        "createdAt": "Thu Nov 11 2015 14:30:48 GMT+0000 (GMT)",
+        "key": "second-key-1",
+        "requestsPerDay": 1000,
+        "requestsPerMinute": 100,
+        "tier": "Internal",
         "status": "active",
-        "tier": "internal",
-        "requestsPerDay": "1000",
-        "requestsPerMinute": "100"
+        "createdAt": "Nov 11 2015 14:30:48"
       },
       {
-        "key": "some-other-key-2",
-        "createdAt": "Thu Nov 11 2015 14:29:48 GMT+0000 (GMT)",
+        "key": "second-key-2",
+        "requestsPerDay": 1000,
+        "requestsPerMinute": 100,
+        "tier": "Developer",
         "status": "active",
-        "tier": "developer",
-        "requestsPerDay": "1000",
-        "requestsPerMinute": "100"
+        "createdAt": "Nov 11 2015 14:29:48"
       }
     ]
   }

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -13,7 +13,7 @@
         "requestsPerDay": 1000,
         "requestsPerMinute": 100,
         "tier": "Developer",
-        "status": "Active",
+        "status": "Inactive",
         "createdAt": "Nov 12 2015 14:29:48"
       },
       {

--- a/integration-test/resources/mashery.json
+++ b/integration-test/resources/mashery.json
@@ -4,7 +4,7 @@
     "email": "test@migratemashery.com",
     "companyName": "Company name",
     "companyUrl": "",
-    "createdAt": "Nov 12 2015 14:29:48",
+    "createdAt": "2015-11-09T14:29:48Z",
     "keys": [
       {
         "key": "first-key-1",
@@ -14,7 +14,7 @@
         "requestsPerMinute": 100,
         "tier": "Developer",
         "status": "Inactive",
-        "createdAt": "Nov 12 2015 14:29:48"
+        "createdAt": "2015-11-09T14:29:48Z"
       },
       {
         "key": "first-key-2",
@@ -24,7 +24,7 @@
         "requestsPerMinute": 100,
         "tier": "Developer",
         "status": "Active",
-        "createdAt": "Nov 11 2015 14:29:48"
+        "createdAt": "2015-11-12T14:29:48Z"
       }
     ]
   },
@@ -33,7 +33,7 @@
     "email": "test2@migratemashery.com",
     "companyName": "Company name",
     "companyUrl": "http://company.com",
-    "createdAt": "Nov 10 2015 17:29:48",
+    "createdAt": "2015-11-10T17:29:48Z",
     "keys": [
       {
         "key": "second-key-1",
@@ -43,7 +43,7 @@
         "requestsPerMinute": 100,
         "tier": "Internal",
         "status": "Active",
-        "createdAt": "Nov 11 2015 14:30:48"
+        "createdAt": "2015-11-12T14:30:48Z"
       },
       {
         "key": "second-key-2",
@@ -53,7 +53,7 @@
         "requestsPerMinute": 100,
         "tier": "Developer",
         "status": "Active",
-        "createdAt": "Nov 11 2015 14:29:48"
+        "createdAt": "2015-11-12T14:29:48Z"
       },
       {
         "key": "second-key-3",
@@ -63,8 +63,16 @@
         "requestsPerMinute": 20,
         "tier": "Developer",
         "status": "Inactive",
-        "createdAt": "Nov 11 2015 14:29:48"
+        "createdAt": "2015-11-12T14:29:48Z"
       }
     ]
+  },
+  {
+    "name": "Third User",
+    "email": "test3@migratemashery.com",
+    "companyName": "Company name",
+    "companyUrl": "",
+    "createdAt": "2015-11-09T14:29:48Z",
+    "keys": []
   }
 ]

--- a/integration-test/scala/integration/IntegrationTests.scala
+++ b/integration-test/scala/integration/IntegrationTests.scala
@@ -413,5 +413,11 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
     status(result) shouldBe 303 // on success it redirects to the message page
     flash(result).get("error") shouldBe defined
   }
+
+  behavior of "migrate users from Mashery"
+
+  it should "take a list of users from Mashery and save them in Kong and Dynamo" in {
+    //TODO: write tests
+  }
 }
 

--- a/integration-test/scala/integration/IntegrationTests.scala
+++ b/integration-test/scala/integration/IntegrationTests.scala
@@ -1,6 +1,6 @@
 package integration
 
-import models.{AdditionalUserInfo, BonoboUser, CommercialRegistration}
+import models._
 import org.joda.time.DateTime
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.{ Matchers, OptionValues, FlatSpec }
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.libs.json._
+
 
 class IntegrationTests extends FlatSpec with Matchers with OptionValues with IntegrationSpecBase with ScalaFutures with Eventually {
 
@@ -419,5 +420,6 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
   it should "take a list of users from Mashery and save them in Kong and Dynamo" in {
     //TODO: write tests
   }
+
 }
 

--- a/integration-test/scala/integration/IntegrationTests.scala
+++ b/integration-test/scala/integration/IntegrationTests.scala
@@ -4,7 +4,6 @@ import models._
 import org.joda.time.DateTime
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.{ Matchers, OptionValues, FlatSpec }
-import play.api.Logger
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
 
@@ -13,56 +12,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.libs.json._
 
-import scala.io.Source
-import scala.util.{Failure, Success}
-
-
 class IntegrationTests extends FlatSpec with Matchers with OptionValues with IntegrationSpecBase with ScalaFutures with Eventually {
-
-  /* HELPER FUNCTIONS */
-
-  def checkConsumerExistsOnKong(consumerId: String): Future[Boolean] = {
-    wsClient.url(s"$kongUrl/consumers/$consumerId").get().map {
-      response =>
-        (response.json \\ "id").headOption match {
-          case Some(JsString(id)) if id == consumerId => true
-          case _ => false
-        }
-    }
-  }
-
-  def checkKeyExistsOnKong(consumerId: String): Future[Boolean] = {
-    wsClient.url(s"$kongUrl/consumers/$consumerId/key-auth").get().map {
-      response =>
-        (response.json \\ "key").headOption match {
-          case Some(JsString(key)) => true
-          case _ => false
-        }
-    }
-  }
-
-  def getKeyForConsumerId(consumerId: String): Future[String] = {
-    wsClient.url(s"$kongUrl/consumers/$consumerId/key-auth").get().map {
-      response =>
-        (response.json \\ "key").headOption match {
-          case Some(JsString(key)) => key
-          case _ => fail()
-        }
-    }
-  }
-
-  def checkRateLimitsMatch(consumerId: String, minutes: Int, day: Int): Future[Boolean] = {
-    wsClient.url(s"$kongUrl/apis/$kongApiName/plugins")
-      .withQueryString("consumer_id" -> consumerId).get().map {
-      response =>
-        (response.json \\ "day").headOption match {
-          case Some(JsNumber(config)) if config.toInt == day => true
-          case _ => false
-        }
-    }
-  }
-
-  /* ACTUAL TESTS */
 
   behavior of "creating a new user with a custom key"
 
@@ -418,6 +368,5 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
     status(result) shouldBe 303 // on success it redirects to the message page
     flash(result).get("error") shouldBe defined
   }
-
 }
 

--- a/integration-test/scala/integration/IntegrationTests.scala
+++ b/integration-test/scala/integration/IntegrationTests.scala
@@ -4,6 +4,7 @@ import models._
 import org.joda.time.DateTime
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.{ Matchers, OptionValues, FlatSpec }
+import play.api.Logger
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
 
@@ -11,6 +12,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.libs.json._
+
+import scala.io.Source
+import scala.util.{Failure, Success}
 
 
 class IntegrationTests extends FlatSpec with Matchers with OptionValues with IntegrationSpecBase with ScalaFutures with Eventually {
@@ -413,12 +417,6 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
 
     status(result) shouldBe 303 // on success it redirects to the message page
     flash(result).get("error") shouldBe defined
-  }
-
-  behavior of "migrate users from Mashery"
-
-  it should "take a list of users from Mashery and save them in Kong and Dynamo" in {
-    //TODO: write tests
   }
 
 }

--- a/integration-test/scala/integration/MigrationIntegrationTests.scala
+++ b/integration-test/scala/integration/MigrationIntegrationTests.scala
@@ -1,0 +1,68 @@
+package integration
+
+import models.{BonoboUser, MasheryRegistration, AdditionalUserInfo, MasheryUser}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{OptionValues, Matchers, FlatSpec}
+import play.api.Logger
+import play.api.libs.json._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Future, Await}
+import scala.io.Source
+import scala.util.{Failure, Success}
+
+class MigrationIntegrationTests extends FlatSpec with Matchers with OptionValues with IntegrationSpecBase with ScalaFutures with Eventually {
+
+  private def checkConsumerExistsOnKong(consumerId: String): Future[Boolean] = {
+    wsClient.url(s"$kongUrl/consumers/$consumerId").get().map {
+      response =>
+        (response.json \\ "id").headOption match {
+          case Some(JsString(id)) if id == consumerId => true
+          case _ => false
+        }
+    }
+  }
+
+  behavior of "migrate users from Mashery"
+
+  it should "take a list of users from Mashery and save them in Kong and Dynamo" in {
+    val masheryJson: JsValue = Json.parse(Source.fromFile("integration-test/resources/mashery.json").mkString)
+    masheryJson should not be JsNull
+
+    val result = route(FakeRequest(POST, "/migrate").withJsonBody(masheryJson)).get
+    status(result) shouldBe 200
+
+    result.onComplete{
+      case Success(_) => {
+        masheryJson.validate[List[MasheryUser]] match {
+          case JsSuccess(j, _) => j.foreach(checkSave)
+          case JsError(errorMessage) => Logger.warn(s"Integration Tests: Error parsing json $errorMessage")
+        }
+      }
+      case Failure(_) => Logger.warn(s"Integration Tests: Error completing request")
+    }
+  }
+
+  private def checkSave(user: MasheryUser): Unit = {
+    val bonoboUser = dynamo.getUserWithEmail(user.email)
+    Logger.info(s"Integration Tests: bonoboUser = $bonoboUser")
+
+    val bonoboId: Option[String] = bonoboUser match {
+      case Some(u) => {
+        Logger.info(s"Integration Tests: bonoboId = ${Some(u.bonoboId)}")
+        Some(u.bonoboId)
+      }
+      case None => None
+    }
+    bonoboId shouldBe defined
+
+    val additionalInfo = AdditionalUserInfo(user.createdAt, MasheryRegistration)
+    val expectedUser = Option(BonoboUser("random_id", user.email, user.name, user.productName, user.productUrl, user.companyName, user.companyUrl, additionalInfo).copy(bonoboId = bonoboId.value))
+    bonoboUser shouldBe expectedUser
+
+    val kongKeys = dynamo.getKeysWithUserId(bonoboUser.value.bonoboId)
+    kongKeys foreach (key => Await.result(checkConsumerExistsOnKong(key.kongId), atMost = 10.seconds) shouldBe true)
+  }
+}

--- a/integration-test/scala/integration/MigrationIntegrationTests.scala
+++ b/integration-test/scala/integration/MigrationIntegrationTests.scala
@@ -1,67 +1,52 @@
 package integration
 
-import models.{BonoboUser, MasheryRegistration, AdditionalUserInfo, MasheryUser}
+import controllers.Migration
+import models._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{OptionValues, Matchers, FlatSpec}
-import play.api.Logger
 import play.api.libs.json._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.duration._
-import scala.concurrent.{Future, Await}
+import scala.concurrent.Await
 import scala.io.Source
-import scala.util.{Failure, Success}
 
 class MigrationIntegrationTests extends FlatSpec with Matchers with OptionValues with IntegrationSpecBase with ScalaFutures with Eventually {
-
-  private def checkConsumerExistsOnKong(consumerId: String): Future[Boolean] = {
-    wsClient.url(s"$kongUrl/consumers/$consumerId").get().map {
-      response =>
-        (response.json \\ "id").headOption match {
-          case Some(JsString(id)) if id == consumerId => true
-          case _ => false
-        }
-    }
-  }
 
   behavior of "migrate users from Mashery"
 
   it should "take a list of users from Mashery and save them in Kong and Dynamo" in {
-    val masheryJson: JsValue = Json.parse(Source.fromFile("integration-test/resources/mashery.json").mkString)
+    val masheryJson = Json.parse(Source.fromFile("integration-test/resources/mashery.json").mkString)
     masheryJson should not be JsNull
 
     val result = route(FakeRequest(POST, "/migrate").withJsonBody(masheryJson)).get
     status(result) shouldBe 200
 
-
     whenReady(result){ r =>
       masheryJson.validate[List[MasheryUser]] match {
-        case JsSuccess(j, _) => j.foreach(checkIfSaved)
+        case JsSuccess(masheryUsers, _) => masheryUsers.foreach(checkIfSaved)
         case JsError(errorMessage) => fail(s"Integration Tests: Error parsing json $errorMessage")
       }
     }
   }
 
-  private def checkIfSaved(user: MasheryUser): Unit = {
-    val bonoboUser = dynamo.getUserWithEmail(user.email)
-    Logger.info(s"Integration Tests: bonoboUser = $bonoboUser")
-
+  private def checkIfSaved(masheryUser: MasheryUser): Unit = {
+    val bonoboUser = dynamo.getUserWithEmail(masheryUser.email)
     val bonoboId: Option[String] = bonoboUser match {
-      case Some(u) => {
-        Logger.info(s"Integration Tests: bonoboId = ${Some(u.bonoboId)}")
-        Some(u.bonoboId)
-      }
+      case Some(u) => Some(u.bonoboId)
       case None => None
     }
     bonoboId shouldBe defined
 
-    val additionalInfo = AdditionalUserInfo(user.createdAt, MasheryRegistration)
-    val expectedUser = Option(BonoboUser("random_id", user.email, user.name, user.companyName, user.companyUrl, additionalInfo).copy(bonoboId = bonoboId.value))
+    val additionalInfo = AdditionalUserInfo(masheryUser.createdAt, MasheryRegistration)
+    val expectedUser = Option(BonoboUser("random_id", masheryUser.email, masheryUser.name, Migration.unspecifiedIfEmpty(masheryUser.companyName), Migration.unspecifiedIfEmpty(masheryUser.companyUrl), additionalInfo).copy(bonoboId = bonoboId.value))
     bonoboUser shouldBe expectedUser
 
-    val kongKeys = dynamo.getKeysWithUserId(bonoboUser.value.bonoboId)
+    val expectedKeys = masheryUser.keys.map(key => KongKey(bonoboId.value, "random", key.key, key.requestsPerDay, key.requestsPerMinute, key.tier, key.status, key.createdAt, key.productName, key.productUrl, "range"))
+    val kongKeys = dynamo.getKeysWithUserId(bonoboId.value)
+    kongKeys foreach (key => key shouldBe expectedKeys.find(k => k.key == key.key).value.copy(kongId = key.kongId, rangeKey = key.rangeKey))
     kongKeys foreach (key => Await.result(checkConsumerExistsOnKong(key.kongId), atMost = 10.seconds) shouldBe true)
+    kongKeys foreach (key => Await.result(checkKeyExistsOnKong(key.kongId), atMost = 10.seconds) shouldBe key.status == KongKey.Active)
   }
 }

--- a/test/controllers/ApplicationSpec.scala
+++ b/test/controllers/ApplicationSpec.scala
@@ -39,7 +39,7 @@ class ApplicationSpec extends FlatSpec with Matchers with MockitoSugar {
       def updateKey(kongKey: KongKey): Unit = ???
 
       def getKeys(direction: String, range: Option[String], limit: Int = 20): ResultsPage[BonoboInfo] = {
-        ResultsPage(List(BonoboInfo(KongKey("bonoboId", "kongId", "my-new-key", 10, 1, Developer, "Active", new DateTime(), "product name", "product url", "rangekey"),
+        ResultsPage(List(BonoboInfo(KongKey("bonoboId", "kongId", "my-new-key", 10, 1, Tier.Developer, "Active", new DateTime(), "product name", "product url", "rangekey"),
           BonoboUser("id", "name", "email", "company name", "company url",
             AdditionalUserInfo(DateTime.now(), ManualRegistration)))), false)
       }


### PR DESCRIPTION
- Migration endpoint has been added in `controllers/Migration.scala`. The endpoint accepts a POST with a json body containing a list of users and saves a new consumer with his keys to Kong and DynamoDb. If the key is marked as `Inactive` it will be deleted from Kong.
- Use enumeratum for Tier model.
- Tests and a json example file have been added.
- Returns a Json containing:
    - the number of successfully added users
   - the number of successfully added keys
   - the list of users with conflicts
   - the list of keys with conflicts

