### PR TITLE
Add field contentFormat and make fields required

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -199,7 +199,7 @@ object Application {
       "name" -> nonEmptyText,
       "email" -> email,
       "companyName" -> nonEmptyText,
-      "companyUrl" -> optional(text),
+      "companyUrl" -> nonEmptyText,
       "productName" -> nonEmptyText,
       "productUrl" -> nonEmptyText,
       "tier" -> nonEmptyText.verifying(invalidTierMessage, tier => Tier.isValid(tier)).transform(tier => Tier.withName(tier).get, (tier: Tier) => tier.toString),
@@ -212,7 +212,7 @@ object Application {
       "name" -> nonEmptyText,
       "email" -> email,
       "companyName" -> nonEmptyText,
-      "companyUrl" -> optional(text)
+      "companyUrl" -> nonEmptyText
     )(EditUserFormData.apply)(EditUserFormData.unapply)
   )
 

--- a/app/controllers/CommercialForm.scala
+++ b/app/controllers/CommercialForm.scala
@@ -60,10 +60,10 @@ object CommercialForm {
       "companyName" -> nonEmptyText,
       "companyUrl" -> nonEmptyText,
       "businessArea" -> nonEmptyText,
-      "monthlyUsers" -> number.verifying(_ > 0),
+      "monthlyUsers" -> number,
       "commercialModel" -> nonEmptyText,
       "content" -> nonEmptyText,
-      "articlesPerDay" -> number.verifying(_ > 0),
+      "articlesPerDay" -> number,
       "contentFormat" -> nonEmptyText,
       "acceptTerms" -> boolean.verifying("You have to accept the Guardian Open Platform terms and conditions.", terms => terms)
     )(CommercialRequestKeyFormData.apply)(CommercialRequestKeyFormData.unapply)

--- a/app/controllers/CommercialForm.scala
+++ b/app/controllers/CommercialForm.scala
@@ -58,12 +58,13 @@ object CommercialForm {
       "productName" -> nonEmptyText,
       "productUrl" -> nonEmptyText,
       "companyName" -> nonEmptyText,
-      "companyUrl" -> optional(text),
-      "businessArea" -> optional(text),
-      "monthlyUsers" -> optional(number),
-      "commercialModel" -> optional(text),
-      "content" -> optional(text),
-      "articlesPerDay" -> optional(number),
+      "companyUrl" -> nonEmptyText,
+      "businessArea" -> nonEmptyText,
+      "monthlyUsers" -> number.verifying(_ > 0),
+      "commercialModel" -> nonEmptyText,
+      "content" -> nonEmptyText,
+      "articlesPerDay" -> number.verifying(_ > 0),
+      "contentFormat" -> nonEmptyText,
       "acceptTerms" -> boolean.verifying("You have to accept the Guardian Open Platform terms and conditions.", terms => terms)
     )(CommercialRequestKeyFormData.apply)(CommercialRequestKeyFormData.unapply)
   )

--- a/app/controllers/DeveloperForm.scala
+++ b/app/controllers/DeveloperForm.scala
@@ -57,7 +57,7 @@ object DeveloperForm {
       "productName" -> nonEmptyText,
       "productUrl" -> nonEmptyText,
       "companyName" -> nonEmptyText,
-      "companyUrl" -> optional(text),
+      "companyUrl" -> nonEmptyText,
       "acceptTerms" -> boolean.verifying("You have to accept the Guardian Open Platform terms and conditions.", terms => terms)
     )(DeveloperCreateKeyFormData.apply)(DeveloperCreateKeyFormData.unapply)
   )

--- a/app/controllers/Forms.scala
+++ b/app/controllers/Forms.scala
@@ -4,9 +4,9 @@ import models.Tier
 
 object Forms {
 
-  case class CreateUserFormData(name: String, email: String, companyName: String, companyUrl: Option[String], productName: String, productUrl: String, tier: Tier, key: Option[String] = None)
+  case class CreateUserFormData(name: String, email: String, companyName: String, companyUrl: String, productName: String, productUrl: String, tier: Tier, key: Option[String] = None)
 
-  case class EditUserFormData(name: String, email: String, companyName: String, companyUrl: Option[String])
+  case class EditUserFormData(name: String, email: String, companyName: String, companyUrl: String)
 
   case class CreateKeyFormData(key: Option[String], tier: Tier, productName: String, productUrl: String)
 
@@ -16,9 +16,9 @@ object Forms {
 
   case class SearchFormData(query: String)
 
-  case class DeveloperCreateKeyFormData(name: String, email: String, productName: String, productUrl: String, companyName: String, companyUrl: Option[String], acceptTerms: Boolean)
+  case class DeveloperCreateKeyFormData(name: String, email: String, productName: String, productUrl: String, companyName: String, companyUrl: String, acceptTerms: Boolean)
 
-  case class CommercialRequestKeyFormData(name: String, email: String, productName: String, productUrl: String, companyName: String, companyUrl: Option[String],
-    businessArea: Option[String], monthlyUsers: Option[Int], commercialModel: Option[String], content: Option[String], articlesPerDay: Option[Int], acceptTerms: Boolean)
+  case class CommercialRequestKeyFormData(name: String, email: String, productName: String, productUrl: String, companyName: String, companyUrl: String,
+    businessArea: String, monthlyUsers: Int, commercialModel: String, content: String, articlesPerDay: Int, contentFormat: String, acceptTerms: Boolean)
 
 }

--- a/app/email/AwsEmailClient.scala
+++ b/app/email/AwsEmailClient.scala
@@ -52,7 +52,7 @@ class AwsEmailClient(amazonMailClient: AmazonSimpleEmailServiceAsyncClient, from
       |Name: ${user.name}
       |Email: ${user.email}
       |Company name: ${user.companyName}
-      |Company URL: ${user.companyUrl.getOrElse('-')}
+      |Company URL: ${user.companyUrl}
       |Product name: $productName
       |Product URL: $productUrl
       |Business area: ${user.additionalInfo.businessArea.getOrElse('-')}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -10,28 +10,28 @@ case class BonoboUser(
   email: String,
   name: String,
   companyName: String,
-  companyUrl: Option[String],
+  companyUrl: String,
   additionalInfo: AdditionalUserInfo)
 
 object BonoboUser {
   /* Method used when manually creating a new user */
   def apply(id: String, formData: CreateUserFormData): BonoboUser = {
-    val additionalInfo = AdditionalUserInfo(DateTime.now(), ManualRegistration, None, None, None, None, None)
+    val additionalInfo = AdditionalUserInfo(DateTime.now(), ManualRegistration)
     new BonoboUser(id, formData.email, formData.name, formData.companyName, formData.companyUrl, additionalInfo)
   }
   /* Method used when editing a new user */
   def apply(id: String, formData: EditUserFormData, createdAt: DateTime, registrationType: RegistrationType): BonoboUser = {
-    val additionalInfo = AdditionalUserInfo(createdAt, registrationType, None, None, None, None, None)
+    val additionalInfo = AdditionalUserInfo(createdAt, registrationType)
     new BonoboUser(id, formData.email, formData.name, formData.companyName, formData.companyUrl, additionalInfo)
   }
   /* Method used when using the developer form for creating a new user */
   def apply(id: String, formData: DeveloperCreateKeyFormData): BonoboUser = {
-    val additionalInfo = AdditionalUserInfo(DateTime.now(), DeveloperRegistration, None, None, None, None, None)
+    val additionalInfo = AdditionalUserInfo(DateTime.now(), DeveloperRegistration)
     new BonoboUser(id, formData.email, formData.name, formData.companyName, formData.companyUrl, additionalInfo)
   }
   /* Method used when using the commercial form for creating a new user */
   def apply(formData: CommercialRequestKeyFormData): BonoboUser = {
-    val additionalInfo = AdditionalUserInfo(DateTime.now(), CommercialRegistration, formData.businessArea, formData.monthlyUsers.map(_.toString), formData.commercialModel, formData.content, formData.articlesPerDay.map(_.toString))
+    val additionalInfo = AdditionalUserInfo(DateTime.now(), CommercialRegistration, Some(formData.businessArea), Some(formData.monthlyUsers.toString), Some(formData.commercialModel), Some(formData.content), Some(formData.contentFormat), Some(formData.articlesPerDay.toString))
     new BonoboUser(java.util.UUID.randomUUID().toString, formData.email, formData.name, formData.companyName, formData.companyUrl, additionalInfo)
   }
 }
@@ -43,7 +43,14 @@ case class AdditionalUserInfo(
   monthlyUsers: Option[String],
   commercialModel: Option[String],
   content: Option[String],
+  contentFormat: Option[String],
   articlesPerDay: Option[String])
+
+object AdditionalUserInfo {
+  def apply(date: DateTime, registrationType: RegistrationType): AdditionalUserInfo = {
+    new AdditionalUserInfo(date, registrationType, None, None, None, None, None, None)
+  }
+}
 
 /* model used for saving the keys on Kong */
 case class KongKey(

--- a/app/store/Dynamo.scala
+++ b/app/store/Dynamo.scala
@@ -81,10 +81,7 @@ class Dynamo(db: DynamoDB, usersTable: String, keysTable: String) extends DB {
       new AttributeUpdate("email").put(bonoboUser.email),
       new AttributeUpdate("name").put(bonoboUser.name),
       new AttributeUpdate("companyName").put(bonoboUser.companyName),
-      bonoboUser.companyUrl match {
-        case Some(url) => new AttributeUpdate("companyUrl").put(url)
-        case None => new AttributeUpdate("companyUrl").delete()
-      }
+      new AttributeUpdate("companyName").put(bonoboUser.companyUrl)
     )
     Logger.info(s"DynamoDB: User ${bonoboUser.bonoboId} has been updated")
   }
@@ -232,14 +229,15 @@ object Dynamo {
       .withString("name", bonoboKey.name)
       .withString("email", bonoboKey.email)
       .withString("companyName", bonoboKey.companyName)
+      .withString("companyUrl", bonoboKey.companyUrl)
       .withLong("createdAt", bonoboKey.additionalInfo.createdAt.getMillis)
       .withString("registrationType", bonoboKey.additionalInfo.registrationType.friendlyName)
 
-    bonoboKey.companyUrl.fold(item) { url => item.withString("companyUrl", url) }
     bonoboKey.additionalInfo.businessArea.fold(item) { businessArea => item.withString("businessArea", businessArea) }
     bonoboKey.additionalInfo.monthlyUsers.fold(item) { monthlyUsers => item.withString("monthlyUsers", monthlyUsers) }
     bonoboKey.additionalInfo.commercialModel.fold(item) { commercialModel => item.withString("commercialModel", commercialModel) }
     bonoboKey.additionalInfo.content.fold(item) { content => item.withString("content", content) }
+    bonoboKey.additionalInfo.contentFormat.fold(item) { contentFormat => item.withString("contentFormat", contentFormat) }
     bonoboKey.additionalInfo.articlesPerDay.fold(item) { articlesPerDay => item.withString("articlesPerDay", articlesPerDay) }
   }
 
@@ -255,13 +253,14 @@ object Dynamo {
       name = item.getString("name"),
       email = item.getString("email"),
       companyName = item.getString("companyName"),
-      companyUrl = Option(item.getString("companyUrl")),
+      companyUrl = item.getString("companyUrl"),
       additionalInfo = AdditionalUserInfo(createdAt = new DateTime(item.getString("createdAt").toLong),
         registrationType = toRegistrationType(item.getString("registrationType")),
         businessArea = Option(item.getString("businessArea")),
         monthlyUsers = Option(item.getString("monthlyUsers")),
         commercialModel = Option(item.getString("commercialModel")),
         content = Option(item.getString("content")),
+        contentFormat = Option(item.getString("contentFormat")),
         articlesPerDay = Option(item.getString("articlesPerDay")))
     )
   }

--- a/app/views/commercialRequestKey.scala.html
+++ b/app/views/commercialRequestKey.scala.html
@@ -28,6 +28,7 @@
                 </div>
                 <div class="col-md-6">
                     @b3.text(keyForm("content"), '_label -> "What content do you intend to display?", 'placeholder -> "e.g. sport, culture")
+                    @b3.text(keyForm("contentFormat"), '_label -> "Content format", 'placeholder -> "e.g. text, images, video")
                     @b3.number(keyForm("monthlyUsers"), '_label -> "Currently monthly users", 'min -> "0" )
                 </div>
             </div>

--- a/integration-test/scala/integration/IntegrationTests.scala
+++ b/integration-test/scala/integration/IntegrationTests.scala
@@ -345,12 +345,13 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
       name = "Joe Bloggs",
       email = "test@commercialform.com",
       companyName = "The Test Company",
-      companyUrl = Some("http://thetestcompany.co.uk"),
+      companyUrl = "http://thetestcompany.co.uk",
       additionalInfo = AdditionalUserInfo(
         businessArea = Some("News"),
         monthlyUsers = Some("100"),
         commercialModel = Some("Model"),
         content = Some("News"),
+        contentFormat = Some("Text"),
         articlesPerDay = Some("20"),
         createdAt = DateTime.now(),
         registrationType = CommercialRegistration))
@@ -358,13 +359,14 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
       "name" -> userToSave.name,
       "email" -> userToSave.email,
       "companyName" -> userToSave.companyName,
-      "companyUrl" -> userToSave.companyUrl.value,
+      "companyUrl" -> userToSave.companyUrl,
       "productName" -> "Product",
       "productUrl" -> "http://product.co.uk",
       "businessArea" -> userToSave.additionalInfo.businessArea.value,
       "monthlyUsers" -> userToSave.additionalInfo.monthlyUsers.value,
       "commercialModel" -> userToSave.additionalInfo.commercialModel.value,
       "content" -> userToSave.additionalInfo.content.value,
+      "contentFormat" -> userToSave.additionalInfo.contentFormat.value,
       "articlesPerDay" -> userToSave.additionalInfo.articlesPerDay.value,
       "acceptTerms" -> "true"
     )).get
@@ -382,12 +384,13 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
       name = "Joe Bloggs",
       email = "test-email@commercialform.com",
       companyName = "The Test Company",
-      companyUrl = Some("http://thetestcompany.co.uk"),
+      companyUrl = "http://thetestcompany.co.uk",
       additionalInfo = AdditionalUserInfo(
         businessArea = Some("News"),
         monthlyUsers = Some("100"),
         commercialModel = Some("Model"),
         content = Some("News"),
+        contentFormat = Some("Text"),
         articlesPerDay = Some("20"),
         createdAt = DateTime.now(),
         registrationType = CommercialRegistration))
@@ -395,13 +398,14 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
       "name" -> userToSave.name,
       "email" -> userToSave.email,
       "companyName" -> userToSave.companyName,
-      "companyUrl" -> userToSave.companyUrl.value,
+      "companyUrl" -> userToSave.companyUrl,
       "productName" -> "Product",
       "productUrl" -> "http://product.co.uk",
       "businessArea" -> userToSave.additionalInfo.businessArea.value,
       "monthlyUsers" -> userToSave.additionalInfo.monthlyUsers.value,
       "commercialModel" -> userToSave.additionalInfo.commercialModel.value,
       "content" -> userToSave.additionalInfo.content.value,
+      "contentFormat" -> userToSave.additionalInfo.contentFormat.value,
       "articlesPerDay" -> userToSave.additionalInfo.articlesPerDay.value,
       "acceptTerms" -> "true"
     )).get

--- a/test/controllers/ApplicationSpec.scala
+++ b/test/controllers/ApplicationSpec.scala
@@ -41,7 +41,7 @@ class ApplicationSpec extends FlatSpec with Matchers with MockitoSugar {
       def getKeys(direction: String, range: Option[String], limit: Int = 20): ResultsPage[BonoboInfo] = {
         ResultsPage(List(BonoboInfo(KongKey("bonoboId", "kongId", "my-new-key", 10, 1, Developer, "Active", new DateTime(), "product name", "product url", "rangekey"),
           BonoboUser("id", "name", "email", "company name", "company url",
-            AdditionalUserInfo(DateTime.now(), ManualRegistration, None, None, None, None, None)))), false)
+            AdditionalUserInfo(DateTime.now(), ManualRegistration)))), false)
       }
 
       def getKeyWithUserId(id: String): Option[KongKey] = ???

--- a/test/controllers/ApplicationSpec.scala
+++ b/test/controllers/ApplicationSpec.scala
@@ -40,7 +40,7 @@ class ApplicationSpec extends FlatSpec with Matchers with MockitoSugar {
 
       def getKeys(direction: String, range: Option[String], limit: Int = 20): ResultsPage[BonoboInfo] = {
         ResultsPage(List(BonoboInfo(KongKey("bonoboId", "kongId", "my-new-key", 10, 1, Developer, "Active", new DateTime(), "product name", "product url", "rangekey"),
-          BonoboUser("id", "name", "email", "company name", Some("company url"),
+          BonoboUser("id", "name", "email", "company name", "company url",
             AdditionalUserInfo(DateTime.now(), ManualRegistration, None, None, None, None, None)))), false)
       }
 


### PR DESCRIPTION
- Add the `contentFormat` field for the commercial form
- Make all form fields required (except for `key`)