### PR TITLE
Use mashery date to create the kong key

### DIFF
--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -84,7 +84,7 @@ object KongKey {
 
   /* model used in the migration endpoint */
   def apply(bonoboId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier, productName: String, productUrl: String, status: String, date: DateTime): KongKey = {
-    new KongKey(bonoboId, consumer.id, consumer.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, tier, status, date, productName, productUrl, uniqueRangeKey(consumer.createdAt))
+    new KongKey(bonoboId, consumer.id, consumer.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, tier, status, date, productName, productUrl, uniqueRangeKey(date))
   }
 }
 


### PR DESCRIPTION
This fixes the bug from the migration endpoint. The Kong `createdAt` was being used instead of the Mashery create date.