### PR TITLE
Don't migrate things in parallel because Kong doesn't like it

### DIFF
--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -181,7 +181,7 @@ case class MasheryKey(
   status: String,
   createdAt: DateTime)
 
-case class MigrationResult(successfullyManagedUsers: Int, successfullyManagedKeys: Int, userConflicts: List[EmailConflict], keyConflicts: List[KeyConflict])
+case class MigrationResult(successfullyManagedUsers: Int, successfullyManagedKeys: Int, userConflicts: List[EmailConflict], failedKeys: List[String])
 
 sealed trait MigrateUserResult
 case class MigratedUser(keyResults: List[MigrateKeyResult]) extends MigrateUserResult
@@ -190,6 +190,7 @@ case class EmailConflict(email: String) extends MigrateUserResult
 sealed trait MigrateKeyResult
 case object MigratedKey extends MigrateKeyResult
 case class KeyConflict(key: String) extends MigrateKeyResult
+case class ThrewException(key: String) extends MigrateKeyResult
 
 case object EmailConflict {
   implicit val emailConflictWrites = Json.writes[EmailConflict]


### PR DESCRIPTION
Kong occasionally generates duplicate UUIDs (!!) for consumer IDs. Work
around by only trying to create one key at a time.

Also better error handling and logging.