### PR TITLE
Fix hanging promise when using dummy email sending logic

### DIFF
--- a/app/email/AwsEmailClient.scala
+++ b/app/email/AwsEmailClient.scala
@@ -20,37 +20,39 @@ trait MailClient {
 class AwsEmailClient(amazonMailClient: AmazonSimpleEmailServiceAsyncClient, fromAddress: String, enableEmail: Boolean) extends MailClient {
 
   private def sendEmail(address: String, subject: String, message: String): Future[SendEmailResult] = {
-    Logger.debug(s"Sending $subject to $address")
-
-    val destination = new Destination().withToAddresses(address)
-
-    val emailSubject = new Content().withData(subject)
-    val textBody = new Content().withData(message)
-    val body = new Body().withText(textBody)
-
-    val emailMessage = new Message().withSubject(emailSubject).withBody(body)
-
-    val request = new SendEmailRequest().withSource(fromAddress).withDestination(destination).withMessage(emailMessage)
-
-    val promise = Promise[SendEmailResult]()
-    val responseHandler = new AsyncHandler[SendEmailRequest, SendEmailResult] {
-      override def onError(e: Exception) = {
-        Logger.warn(s"Could not send mail: ${e.getMessage}\n" +
-          s"The failing request was $request")
-        promise.failure(e)
-      }
-
-      override def onSuccess(request: SendEmailRequest, result: SendEmailResult) = {
-        Logger.info("The email has been successfully sent")
-        promise.success(result)
-      }
-    }
     if (enableEmail) {
+      Logger.debug(s"Sending $subject to $address")
+
+      val destination = new Destination().withToAddresses(address)
+
+      val emailSubject = new Content().withData(subject)
+      val textBody = new Content().withData(message)
+      val body = new Body().withText(textBody)
+
+      val emailMessage = new Message().withSubject(emailSubject).withBody(body)
+
+      val request = new SendEmailRequest().withSource(fromAddress).withDestination(destination).withMessage(emailMessage)
+
+      val promise = Promise[SendEmailResult]()
+      val responseHandler = new AsyncHandler[SendEmailRequest, SendEmailResult] {
+        override def onError(e: Exception) = {
+          Logger.warn(s"Could not send mail: ${e.getMessage}\n" +
+            s"The failing request was $request")
+          promise.failure(e)
+        }
+
+        override def onSuccess(request: SendEmailRequest, result: SendEmailResult) = {
+          Logger.info("The email has been successfully sent")
+          promise.success(result)
+        }
+      }
       amazonMailClient.sendEmailAsync(request, responseHandler)
+
+      promise.future
     } else {
       Logger.info("Emails are not enabled. The email was not sent.")
+      Future.successful(new SendEmailResult)
     }
-    promise.future
   }
 
   def sendEmailCommercialRequestToModerators(user: BonoboUser, productName: String, productUrl: String)(implicit request: RequestHeader): Future[SendEmailResult] = {


### PR DESCRIPTION
When we decide not to send an email (because we are in a pre-prod environment), we were not completing the promise, so the future never completed.