### PR TITLE
[Security] Check that the user is guardian staff

### DIFF
--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -30,6 +30,9 @@ class Auth(val authConfig: GoogleAuthConfig, ws: WSAPI) extends Controller with 
         Future.successful(Forbidden("Anti forgery token missing in session"))
       case Some(token) =>
         GoogleAuth.validatedUserIdentity(authConfig, token, ws).map { identity =>
+
+          if (!isGuardianStaff(identity)) throw new Exception("not a guardian staff")
+
           // We store the URL a user was trying to get to in the LOGIN_ORIGIN_KEY in AuthAction
           // Redirect a user back there now if it exists
           val redirect = session.get(LOGIN_ORIGIN_KEY) match {
@@ -48,6 +51,9 @@ class Auth(val authConfig: GoogleAuthConfig, ws: WSAPI) extends Controller with 
         }
     }
   }
+
+  private def isGuardianStaff(identity: UserIdentity): Boolean = identity.email.split("@").last == "guardian.co.uk"
+
 }
 
 object Auth {


### PR DESCRIPTION
Not sure why [google-auth](https://github.com/guardian/play-googleauth) is not checking the domain, as I would have expecting it do the check, but [flexible code check the actual email address domain of the user](https://github.com/guardian/flexible-content/blob/d04957c030a00fb513046ff5f50a8b5e5f413c96/flexible-content-composer-backend/src/main/scala/com/gu/flexiblecontent/composerbackend/dispatcher/PanDomainAuthenticatedUser.scala#L215-L225) so do the same.

@cb372 @adamnfish @sihil 