### PR TITLE
Improve Bonobo access logging

### DIFF
--- a/cloudformation.json.CODE
+++ b/cloudformation.json.CODE
@@ -140,7 +140,13 @@
             "Key": "App",
             "Value": "bonobo"
           }
-        ]
+        ],
+        "AccessLoggingPolicy": {
+          "EmitInterval": 60,
+          "Enabled": "true",
+          "S3BucketName": "content-api-logs",
+          "S3BucketPrefix": { "Fn::Join": [ "", [ "bonobo/",{ "Ref": "Stage" } ] ] }
+        }
       }
     },
     "AutoscalingGroup": {

--- a/cloudformation.json.PROD
+++ b/cloudformation.json.PROD
@@ -140,7 +140,13 @@
             "Key": "App",
             "Value": "bonobo"
           }
-        ]
+        ],
+        "AccessLoggingPolicy": {
+          "EmitInterval": 60,
+          "Enabled": "true",
+          "S3BucketName": "content-api-logs",
+          "S3BucketPrefix": { "Fn::Join": [ "", [ "bonobo/",{ "Ref": "Stage" } ] ] }
+        }
       }
     },
     "AutoscalingGroup": {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -15,6 +15,21 @@
     <logger name="play" level="INFO" />
     <logger name="com.google.api.client.http" level="WARN" />
 
+    <appender name="auditFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/audit.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/audit.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%date - %msg%n%xException{300}</pattern>
+        </encoder>
+    </appender>
+    
+    <logger name="audit" level="INFO" additivity="false">
+        <appender-ref ref="auditFile"/>
+    </logger>
+
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date [%thread] %-5level %logger{20} - %msg%n%xException{30}</pattern>


### PR DESCRIPTION
1. Enable ELB access logs with CloudFormation
2. Add access logs to the Bonobo app, to provide better details about the user in a separate `audit.log` file.

The format of the new Bonobo log file is e.g.:
```
2016-02-16 17:39:20,056 - tom.forbes@guardian.co.uk GET /
2016-02-16 17:39:25,780 - tom.forbes@guardian.co.uk GET /key/search?query=test
2016-02-16 17:39:28,819 - tom.forbes@guardian.co.uk GET /user/<id>/edit
2016-02-16 17:39:31,852 - tom.forbes@guardian.co.uk POST /user/<id>/edit - Some(Map(csrfToken -> ArrayBuffer(<token>), name -> ArrayBuffer(Chris Test), email -> ArrayBuffer(chris.birchall+testtest@theguardian.com), companyName -> ArrayBuffer(The Guardian - testing), companyUrl -> ArrayBuffer(http://theguardian.com), labelIds -> ArrayBuffer()))
```