### PR TITLE
Redirect http -> https on Bonobo

### DIFF
--- a/app/components/AppComponents.scala
+++ b/app/components/AppComponents.scala
@@ -123,7 +123,10 @@ trait LabelsComponentImpl extends LabelsComponent with DynamoComponent {
 }
 
 trait CSRFComponent { self: BuiltInComponents =>
-  override lazy val httpFilters = Seq(CSRFFilter(CSRFConfig(), new ConfigTokenProvider(CSRFConfig())))
+  override lazy val httpFilters = Seq(
+    CSRFFilter(CSRFConfig(), new ConfigTokenProvider(CSRFConfig())),
+    HttpsRedirectFilter.fromConfiguration(configuration)
+  )
 }
 
 trait ControllersComponent {

--- a/app/components/HttpsRedirectFilter.scala
+++ b/app/components/HttpsRedirectFilter.scala
@@ -1,0 +1,31 @@
+package components
+
+import play.api.Configuration
+import play.api.mvc.Filter
+import play.api.mvc.RequestHeader
+import play.api.mvc.Result
+import play.api.mvc.Results.Redirect
+import scala.concurrent.Future
+
+class HttpsRedirectFilter(enabled: Boolean = HttpsRedirectFilter.DEFAULT_ENABLED,
+    sslPort: String = HttpsRedirectFilter.DEFAULT_SSL_PORT) extends Filter {
+
+  def isHealthCheck(uri: String) = uri == "/healthcheck"
+
+  def apply(nextFilter: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] =
+    if (enabled && !request.secure && !isHealthCheck(request.uri))
+      Future successful Redirect(s"https://${request.domain}:${sslPort}${request.uri}").withHeaders("Strict-Transport-Security" -> "max-age=31536000; includeSubDomains")
+    else nextFilter(request)
+}
+
+object HttpsRedirectFilter {
+
+  val DEFAULT_SSL_PORT = "443"
+  val DEFAULT_ENABLED = true
+
+  def fromConfiguration(configuration: Configuration) =
+    new HttpsRedirectFilter(
+      configuration.getBoolean("httpsRedirectFilter.enabled").getOrElse(DEFAULT_ENABLED),
+      configuration.getString("httpsRedirectFilter.sslPort").getOrElse(DEFAULT_SSL_PORT)
+    )
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -16,3 +16,6 @@ google.clientSecret = "RwPmzy6BmwT_7OGUpSe7XxG5"
 google.redirectUrl = "http://localhost:9000/oauth2callback"
 
 email.enabled=false
+
+# Only set to false in development environment. Defaults to true
+httpsRedirectFilter.enabled = false


### PR DESCRIPTION
This is one of the things that came out of our security review.
Both CODE + PROD still listen on port 80.
A filter in the play app redirects all http requests to https by default. This can be disabled with the httpsRedirectFilter.enabled config item, for running locally.