### PR TITLE
Make the Play session cookie secure

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,6 +6,8 @@ kong.apiAddress = "http://localhost:8001"
 # This must be overwritten in PROD, or else the app won't start
 play.crypto.secret = "changeme"
 
+play.http.session.secure=true
+
 play.i18n.langs = [ "en" ]
 
 play.application.loader = AppLoader


### PR DESCRIPTION
First curl is made using `secure` set to true.

![file-page1](https://cloud.githubusercontent.com/assets/5732563/13494347/8b614344-e13b-11e5-8eae-c5ec72f9c899.jpg)
