### PR TITLE
Use https url in the email

### DIFF
--- a/app/email/AwsEmailClient.scala
+++ b/app/email/AwsEmailClient.scala
@@ -68,7 +68,7 @@ class AwsEmailClient(amazonMailClient: AmazonSimpleEmailServiceAsyncClient, from
       |Content type: ${user.additionalInfo.content.getOrElse('-')}
       |Monthly users: ${user.additionalInfo.monthlyUsers.getOrElse('-')}
       |Articles per day: ${user.additionalInfo.articlesPerDay.getOrElse('-')}
-      |${controllers.routes.Application.editUserPage(user.bonoboId).absoluteURL()}""".stripMargin
+      |${controllers.routes.Application.editUserPage(user.bonoboId).absoluteURL().replace("http://", "https://")}""".stripMargin
     sendEmail("content.delivery@theguardian.com", "Commercial Key Request", message)
   }
 


### PR DESCRIPTION
This is dirty workaround but as `request.secure` is broken.