### PR TITLE
Set session.secure=false when running locally

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,12 +1,13 @@
 # This is the main configuration file for the application.
 # ~~~~~
 kong.apiName = "internal"
-kong.apiAddress = "http://localhost:8001"
+kong.apiAddress = "http://192.168.99.100:8001"
 
 # This must be overwritten in PROD, or else the app won't start
 play.crypto.secret = "changeme"
 
-play.http.session.secure=true
+# This will be overwritten to true in PROD, where we are running HTTPS
+play.http.session.secure = false
 
 play.i18n.langs = [ "en" ]
 


### PR DESCRIPTION
If we set it to true then the session becomes a secure cookie, which doesn't work because Play runs on http://localhost:9000

I've updated the CODE and PROD config files to overwrite it to true.