### PR TITLE
docker-compose-ify dev bootstrap scripts

### DIFF
--- a/scripts/configure-docker.sh
+++ b/scripts/configure-docker.sh
@@ -1,10 +1,14 @@
 #! /bin/bash
 
+docker_host=${DOCKER_HOST?Docker host is not set}
+
+container_host=$(echo ${docker_host} | sed -e 's/tcp:\/\/\(.*\):.*/\1/')
+
 echo Starting Services ...
 docker-compose up -d
 
 echo Adding API ...
-wget -O - http://127.0.0.1:8001/apis --post-data 'name=internal&request_host=foo.com&upstream_url=http://example.com' --retry-connrefused --no-verbose
+wget -O - http://${container_host}:8001/apis --post-data 'name=internal&request_host=foo.com&upstream_url=http://example.com' --retry-connrefused --no-verbose
 
 echo Activating key-auth plugin ...
-wget -O - http://127.0.0.1:8001/apis/internal/plugins/ --post-data 'name=key-auth' --retry-connrefused --no-verbose
+wget -O - http://${container_host}:8001/apis/internal/plugins/ --post-data 'name=key-auth' --retry-connrefused --no-verbose

--- a/scripts/configure-docker.sh
+++ b/scripts/configure-docker.sh
@@ -1,45 +1,10 @@
 #! /bin/bash
 
-docker_host=${DOCKER_HOST?Docker host is not set}
-
-container_host=$(echo ${docker_host} | sed -e 's/tcp:\/\/\(.*\):.*/\1/')
-
-function start_service {
-    name=${1?Name parameter missing}
-    port_number=${2?Port parameter missing}
-
-    docker start ${name}
-
-    nc -z ${container_host} ${port_number}
-    while [ $? -ne 0 ]; do
-        echo Waiting for ${name} to start listening ...
-        sleep 1
-        nc -z ${container_host} ${port_number}
-    done
-}
-
-if docker ps | grep cassandra -q; then
-    echo Cassandra container already exists
-else
-    echo Creating cassandra container ...
-    docker create -p 9042:9042 --name cassandra mashape/cassandra
-fi
-
-
-if docker ps | grep kong -q; then
-    echo Kong container already exists
-else
-    echo Creating kong container ...
-    docker create -p 8000:8000 -p 8001:8001 --name kong --link cassandra:cassandra mashape/kong:0.7.0
-fi
-
-start_service cassandra 9042
-
-start_service kong 8001
+echo Starting Services ...
+docker-compose up -d
 
 echo Adding API ...
-curl -sS -X POST http://${container_host}:8001/apis -d name=internal -d request_host=foo.com -d upstream_url=http://example.com
+wget -O - http://127.0.0.1:8001/apis --post-data 'name=internal&request_host=foo.com&upstream_url=http://example.com' --retry-connrefused --no-verbose
 
 echo Activating key-auth plugin ...
-curl -sS -X POST http://${container_host}:8001/apis/internal/plugins/ -d name=key-auth
-
+wget -O - http://127.0.0.1:8001/apis/internal/plugins/ --post-data 'name=key-auth' --retry-connrefused --no-verbose

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   kong:
     image: mashape/kong:0.9.0
     restart: always
-    dns:
-      - 10.0.0.1
     depends_on:
       - postgres
     environment:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  
+  kong:
+    image: mashape/kong:0.7.0
+    restart: always
+    depends_on:
+      - cassandra
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+
+  cassandra:
+    image: mashape/cassandra


### PR DESCRIPTION
addresses #112 by internally changing the `scripts/configure-docker.sh` script to use `docker-compose` and `docker-compose.yml`. It's not the cleanest solution (I think when the new `HEALTHCHECK` directive has better support this can be made much cleaner) but it works locally - which I believe is the purpose here.

I don't know how to test it further than those two POST requests returning 201's.

I often see a warning appear, the consequences of which I'm unfamiliar with:

> kong_1       | [WARN] Cannot auto-join the cluster because no nodes were found

although the whole thing still seems to work.

You may also be interested in more advanced setups by the kong guys themselves [here](https://github.com/Mashape/docker-kong/blob/master/compose/docker-compose.yml)

If there needs to be some sort of persistence, I can try to bake that in too but I'm not too familiar with cassandra.
