### PR TITLE
Bonobo - remove kongId from KongKey model.

### DIFF
--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -57,7 +57,6 @@ object AdditionalUserInfo {
 /* model used for saving the keys on Kong */
 case class KongKey(
   bonoboId: String,
-  kongId: Option[String], // to be deleted.
   kongConsumerId: String,
   key: String,
   requestsPerDay: Int,
@@ -76,13 +75,11 @@ object KongKey {
   private def uniqueRangeKey(createdAt: DateTime): String = s"${createdAt.getMillis}_${UUID.randomUUID}"
 
   def apply(bonoboId: String, kongConsumerId: String, form: EditKeyFormData, createdAt: DateTime, rateLimits: RateLimits, rangeKey: String): KongKey = {
-    val kongId = None // to be deleted
-    new KongKey(bonoboId, kongId, kongConsumerId, form.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, form.tier, form.status, createdAt, form.productName, form.productUrl, rangeKey)
+    new KongKey(bonoboId, kongConsumerId, form.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, form.tier, form.status, createdAt, form.productName, form.productUrl, rangeKey)
   }
 
   def apply(bonoboId: String, consumer: ConsumerCreationResult, rateLimits: RateLimits, tier: Tier, productName: String, productUrl: Option[String]): KongKey = {
-    val kongId = None // to be deleted
-    new KongKey(bonoboId, kongId, consumer.kongConsumerId, consumer.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, tier, Active, consumer.createdAt, productName, productUrl, uniqueRangeKey(consumer.createdAt))
+    new KongKey(bonoboId, consumer.kongConsumerId, consumer.key, rateLimits.requestsPerDay, rateLimits.requestsPerMinute, tier, Active, consumer.createdAt, productName, productUrl, uniqueRangeKey(consumer.createdAt))
   }
 
 }

--- a/app/store/Dynamo.scala
+++ b/app/store/Dynamo.scala
@@ -390,7 +390,6 @@ object Dynamo {
       .withList("labelIds", labelIds.asJava)
 
     kongKey.productUrl.foreach(productUrl => item.withString("productUrl", productUrl))
-    kongKey.kongId.foreach(kongId => item.withString("kongId", kongId)) // to be deleted
     item
   }
 
@@ -403,7 +402,6 @@ object Dynamo {
     }
     KongKey(
       bonoboId = item.getString("bonoboId"),
-      kongId = Option(item.getString("kongId")), // to be deleted
       kongConsumerId = item.getString("kongConsumerId"),
       key = item.getString("keyValue"),
       requestsPerDay = item.getInt("requests_per_day"),

--- a/integration-test/scala/integration/IntegrationTests.scala
+++ b/integration-test/scala/integration/IntegrationTests.scala
@@ -151,7 +151,6 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
       labelIds = List("id-label-1", "id-label-3"))
     val keyToSave = KongKey(
       bonoboId = "id-user-with-labels",
-      kongId = None, // "to be deleted"
       kongConsumerId = "id-user-with-labels",
       key = "labels-key",
       requestsPerDay = 10,
@@ -190,7 +189,6 @@ class IntegrationTests extends FlatSpec with Matchers with OptionValues with Int
 
     dynamoKongKey.value shouldBe keyToSave.copy(
       bonoboId = consumerId,
-      kongId = None, // to be deleted
       kongConsumerId = consumerId,
       requestsPerDay = dynamoKongKey.value.requestsPerDay,
       requestsPerMinute = dynamoKongKey.value.requestsPerMinute,

--- a/test/controllers/ApplicationSpec.scala
+++ b/test/controllers/ApplicationSpec.scala
@@ -39,8 +39,7 @@ class ApplicationSpec extends FlatSpec with Matchers with MockitoSugar {
       def updateKey(kongKey: KongKey): Unit = ???
 
       def getKeys(direction: String, range: Option[String], limit: Int = 20, filterLabels: Option[List[String]]): ResultsPage[BonoboInfo] = {
-        val kongId = None // to be deleted
-        ResultsPage(List(BonoboInfo(KongKey("bonoboId", kongId, "kongConsumerId", "my-new-key", 10, 1, Tier.Developer, "Active", new DateTime(), "product name", Some("product url"), "rangekey"),
+        ResultsPage(List(BonoboInfo(KongKey("bonoboId", "kongConsumerId", "my-new-key", 10, 1, Tier.Developer, "Active", new DateTime(), "product name", Some("product url"), "rangekey"),
           BonoboUser("id", "name", "email", Some("company name"), Some("company url"),
             AdditionalUserInfo(DateTime.now(), ManualRegistration), List.empty))), false)
       }


### PR DESCRIPTION
- Now that the kong migration is complete, the kongId attribute has been removed
from the keys table in Dynamo for all keys (the canonical source for the consumer id provided by Kong is now kongConsumerId). This means the kongId field can be removed from the KongKey model within Bonobo.