### PR TITLE
Maintenance mode

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -40,3 +40,6 @@ email.enabled=false
 
 # Only set to false in development environment. Defaults to true
 httpsRedirectFilter.enabled = false
+
+# Returns 503 if true
+maintenanceMode = true


### PR DESCRIPTION
For use during Kong upgrades. This will reject all requests (besides /healthcheck) with:
`503 - Server is down for maintenance, please try again later`

This is controlled with a config item, `maintenanceMode`, and Bonobo has to be redeployed to switch on/off. This feature will be used so rarely that it's not really worth doing something more sophisticated.