### PR TITLE
Fix broken registration

### DIFF
--- a/app/controllers/csrf/CSRFSupport.scala
+++ b/app/controllers/csrf/CSRFSupport.scala
@@ -1,7 +1,7 @@
 package controllers.csrf
 
 import play.api.mvc.RequestHeader
-import play.filters.csrf.CSRF.Token
+import play.filters.csrf.CSRF
 import play.filters.csrf.CSRFConfig
 import play.twirl.api.Html
 
@@ -9,8 +9,9 @@ object CSRFSupport {
   val config = CSRFConfig()
 
   def getToken(request: RequestHeader): Option[String] = {
-    // Check cookie if cookie name is defined
-    config.cookieName.flatMap(n => request.cookies.get(n).map(_.value))
+    CSRF.getToken(request).map(_.value)
+      // Check cookie if cookie name is defined
+      .orElse(config.cookieName.flatMap(n => request.cookies.get(n).map(_.value)))
       // Check session
       .orElse(request.session.get(config.tokenName))
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.5")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
 


### PR DESCRIPTION
The [migration to play 2.6](https://github.com/guardian/bonobo/pull/131) break the CSRF token to be populated correcly

@tackley