### PR TITLE
Add the ability to delete keys

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -222,8 +222,11 @@ class Application(
     editKeyForm.bindFromRequest.fold[Future[Result]](handleInvalidForm, handleValidForm)
   }
 
-  def deleteKey(keyId: String) = maybeAuth.async { implicit request => 
-    
+  def deleteKey(keyId: String) = maybeAuth.async { implicit request =>
+    dynamo.getKeyWithValue(keyId) match {
+      case Some(key) => logic.deleteKey(key)
+      case None => Future.successful(NotFound)
+    }    
   }
 
   def getEmails(tier: String, status: String) = maybeAuth { implicit request =>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -222,6 +222,10 @@ class Application(
     editKeyForm.bindFromRequest.fold[Future[Result]](handleInvalidForm, handleValidForm)
   }
 
+  def deleteKey(keyId: String) = maybeAuth.async { implicit request => 
+    
+  }
+
   def getEmails(tier: String, status: String) = maybeAuth { implicit request =>
     Ok(Json.toJson(dynamo.getEmails(tier, status)))
   }

--- a/app/logic/ApplicationLogic.scala
+++ b/app/logic/ApplicationLogic.scala
@@ -168,6 +168,9 @@ class ApplicationLogic(dynamo: DB, kong: Kong) {
     }
   }
 
+  def deleteKey(key: KongKey): Future[Happy.type] =
+    kong.deleteKey(key.consumerId)
+
   private def checkingIfKeyAlreadyTaken[A](key: Option[String])(f: => Future[A]): Future[A] = key match {
     case Some(value) =>
       if (dynamo.isKeyPresent(value))

--- a/app/views/editKey.scala.html
+++ b/app/views/editKey.scala.html
@@ -5,7 +5,7 @@
 
 @main(assets, "Edit key", firstName, pageTitle, success, error) {
     <div class="row">
-        <div class="col-md-6 col-md-offset-2 column">
+        <div class="col-md-8 col-md-offset-1 column">
         @b3.form(routes.Application.editKey(form("key").value.get)) {
             @CSRFSupport.formField
             @b3.text( form("key"), '_label -> "Key", 'readonly -> true )
@@ -18,10 +18,16 @@
             @b3.select( form("status"), options = Seq(KongKey.Active -> "Active", KongKey.Inactive -> "Inactive"), '_label -> "Status" )
             @b3.free('_id -> "idFormGroup") {
                 <button type="submit" class="btn btn-primary"> <span class="glyphicon glyphicon-ok"></span> Save changes</button>
+                <button data-url="@routes.Application.deleteKey(form("key").value.get)" 
+                        data-redirect-url="@routes.Application.editUser(userId)"
+                        type="button" class="btn btn-danger js-delete-key">
+                    <span class="glyphicon glyphicon-remove"></span> Delete key
+                </button>
                 <a href="@routes.Application.editUserPage(userId)" class="btn btn-default"><span class="glyphicon glyphicon-arrow-left"></span> Back to user</a>
             }
         }
         </div>
     </div>
     <script src="@assets.path("javascripts/editKey.js")" type="text/javascript"></script>
+    <script src="@assets.path("javascripts/deleteKey.js")" type="text/javascript"></script>
 }

--- a/app/views/editUser.scala.html
+++ b/app/views/editUser.scala.html
@@ -88,6 +88,7 @@
             <th>Requests per day</th>
             <th>Created at</th>
             <th>Status</th>
+            <th/>
           </tr>
         </thead>
         <tbody>
@@ -101,6 +102,11 @@
             <td>@key.requestsPerDay</td>
             <td>@key.createdAt.toString("dd-MM-yyyy hh:mma")</td>
             <td>@key.status</td>
+            <td><button data-url="@routes.Application.deleteKey(key.key)"
+                        data-redirect-url="@routes.Application.editUser(id)"
+                        type="button" class="btn btn-danger btn-sm js-delete-key">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button></td>
           </tr>
         }
         </tbody>
@@ -109,5 +115,6 @@
     <a href="@routes.Application.createKeyPage(id)" class="btn btn-success" style="margin-bottom: 20px;"><span class="glyphicon glyphicon-plus"></span> Add new key</a>
   </div>
   <script src="@assets.path("javascripts/createUser.js")" type="text/javascript"></script>
+  <script src="@assets.path("javascripts/deleteKey.js")" type="text/javascript"></script>
   <link href="@assets.path("stylesheets/labelStyle.css")" type="text/css" rel="stylesheet"/>
 }

--- a/conf/routes
+++ b/conf/routes
@@ -12,7 +12,7 @@ GET         /key/create/:userId         controllers.Application.createKeyPage(us
 POST        /key/create/:userId         controllers.Application.createKey(userId: String)
 GET         /key/:id/edit               controllers.Application.editKeyPage(id: String)
 POST        /key/:id/edit               controllers.Application.editKey(id: String)
-DELETE      /key/:id                    controllers.Application.deleteKey(id: String)
+DELETE      /key/:id/edit               controllers.Application.deleteKey(id: String)
 
 GET         /user/create                controllers.Application.createUserPage
 POST        /user/create                controllers.Application.createUser

--- a/conf/routes
+++ b/conf/routes
@@ -12,6 +12,7 @@ GET         /key/create/:userId         controllers.Application.createKeyPage(us
 POST        /key/create/:userId         controllers.Application.createKey(userId: String)
 GET         /key/:id/edit               controllers.Application.editKeyPage(id: String)
 POST        /key/:id/edit               controllers.Application.editKey(id: String)
+DELETE      /key/:id                    controllers.Application.deleteKey(id: String)
 
 GET         /user/create                controllers.Application.createUserPage
 POST        /user/create                controllers.Application.createUser

--- a/public/javascripts/deleteKey.js
+++ b/public/javascripts/deleteKey.js
@@ -1,0 +1,13 @@
+Array.from(document.querySelectorAll('.js-delete-key')).forEach(btn => {
+    btn.onclick = e => {
+        e.stopPropagation();
+        let req = new XMLHttpRequest();
+        let url = btn.getAttribute('data-url');
+        let red = btn.getAttribute('data-redirect-url');
+        req.onload = req.onerror = () => {
+          window.location.href = red;
+        };        
+        req.open('DELETE', url, true);
+        req.send();
+    };
+});


### PR DESCRIPTION
This is a first stab at adding the ability to delete API keys. Fortunately the deletion logic in Kong is already there, I just had to add the plumbing.

There is a heavy REST flavour to any Play app so I went all in: I added a DELETE route. 

Sadly, this automatically requires using ajax on the client side. Why `<form action="..." method="delete">` is not allowed is completely beyond me 😩 As a consequence, what happens after deletion must then be handled entirely in JavaScript. The current architecture does not leave a lot of room for callbacks, so I just added some redirect logic for now.

I'm already regretting this decision and wonder if instead I should just add a good old POST route with a path like `/key/:id/delete` and call it a day.