### PR TITLE
Delete keys in Dynamo even if Kong fails

### DIFF
--- a/app/logic/DeveloperFormLogic.scala
+++ b/app/logic/DeveloperFormLogic.scala
@@ -47,7 +47,9 @@ class DeveloperFormLogic(dynamo: DB, kong: Kong) {
     Future { dynamo.getKeysWithUserId(user.bonoboId) } flatMap {
       Future.traverse(_) { key =>
         for {
-          _ <- kong.deleteConsumer(key.kongConsumerId)
+          _ <- kong.deleteConsumer(key.kongConsumerId).recover {
+            case Kong.GenericFailure(txt) if txt.contains("404") => ()
+          }
         } yield {
           dynamo.deleteKey(key)
         }


### PR DESCRIPTION
For some reasons, sometimes Kong will return a 404 when trying to delete a consumer, even if that user has an active key in the bonobo database. I'm catching these errors and cleaning up the DB anyway.