### PR TITLE
Use 'local' rate-limiting policy

### DIFF
--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -99,6 +99,7 @@ class KongClient(ws: WSClient, serverUrl: String, apiName: String) extends Kong 
     ws.url(s"$serverUrl/apis/$apiName/plugins").post(Map(
       "consumer_id" -> Seq(consumerId),
       "name" -> Seq(RateLimitingPluginName),
+      "config.policy" -> Seq("local"),
       "config.minute" -> Seq(rateLimit.requestsPerMinute.toString),
       "config.day" -> Seq(rateLimit.requestsPerDay.toString))).flatMap {
       response =>
@@ -152,6 +153,7 @@ class KongClient(ws: WSClient, serverUrl: String, apiName: String) extends Kong 
         ws.url(s"$serverUrl/apis/$apiName/plugins/$pluginId").patch(Map(
           "consumer_id" -> Seq(consumerId),
           "name" -> Seq(RateLimitingPluginName),
+          "config.policy" -> Seq("local"),
           "config.minute" -> Seq(newRateLimit.requestsPerMinute.toString),
           "config.day" -> Seq(newRateLimit.requestsPerDay.toString))).flatMap {
           response =>


### PR DESCRIPTION
Brings bonobo in line with [this change](https://github.com/guardian/content-api/pull/2184) to the kong rate-limiting plugin.
Drastically reduces DB connections (and instance size), at the cost of less reliable rate-limiting