### PR TITLE
Update build with correct artefact

### DIFF
--- a/bonobo.service
+++ b/bonobo.service
@@ -8,7 +8,7 @@ Restart=on-failure
 Environment='HOME=/home/content-api'
 Environment='JAVA_OPTS=-Xmx256m -Xms256m -XX:+UseConcMarkSweepGC -XX:NewRatio=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:ReservedCodeCacheSize=64m -Dconfig.file=/etc/gu/bonobo.conf'
 WorkingDirectory=/home/content-api
-ExecStart=/home/content-api/bonobo/bin/bonobo
+ExecStart=/home/content-api/bonobo/bonobo-1.0-SNAPSHOT/bin/bonobo
 
 [Install]
 WantedBy=multi-user.target

--- a/cloudformation-CODE.yaml
+++ b/cloudformation-CODE.yaml
@@ -171,13 +171,13 @@ Resources:
             mkdir logs
             mkdir -p /etc/gu
 
-            aws --region eu-west-1 s3 cp s3://content-api-dist/content-api/${Stage}/bonobo/bonobo.zip bonobo.zip
+            aws --region eu-west-1 s3 cp s3://content-api-dist/content-api/${Stage}/bonobo/bonobo-1.0-SNAPSHOT.tgz bonobo.tgz
             aws --region eu-west-1 s3 cp s3://content-api-dist/content-api/${Stage}/bonobo/bonobo.service bonobo.service
 
             mv bonobo.service /etc/systemd/system
 
             mkdir bonobo
-            unzip bonobo.zip -d bonobo
+            tar -xvzf bonobo.tgz -C bonobo
 
             aws s3 cp s3://content-api-config/bonobo/${Stage}/bonobo.conf /etc/gu/bonobo.conf
             aws s3 cp s3://content-api-config/bonobo/bonobo-google-service-account.json /etc/gu/bonobo-google-service-account.json

--- a/cloudformation-PROD.yaml
+++ b/cloudformation-PROD.yaml
@@ -171,12 +171,12 @@ Resources:
             mkdir logs
             mkdir -p /etc/gu
 
-            aws --region eu-west-1 s3 cp s3://content-api-dist/content-api/${Stage}/bonobo/bonobo.zip bonobo.zip
+            aws --region eu-west-1 s3 cp s3://content-api-dist/content-api/${Stage}/bonobo/bonobo-1.0-SNAPSHOT.tgz bonobo.tgz
             aws --region eu-west-1 s3 cp s3://content-api-dist/content-api/${Stage}/bonobo/bonobo.service bonobo.service
 
             mv bonobo.service /etc/systemd/system
             mkdir bonobo
-            unzip bonobo.zip -d bonobo
+            tar -xvzf bonobo.tgz -C bonobo
 
             aws s3 cp s3://content-api-config/bonobo/${Stage}/bonobo.conf /etc/gu/bonobo.conf
             aws s3 cp s3://content-api-config/bonobo/bonobo-google-service-account.json /etc/gu/bonobo-google-service-account.json


### PR DESCRIPTION
The bonobo build failed. That's because I configured the `content-api-dist` repo to remove files older than 1 year. It turns out the build is generating a tar but the launch config is looking for a zip.

Have already tested on CODE