### PR TITLE
Script to look at developer tier keys

### DIFF
--- a/app/store/Dynamo.scala
+++ b/app/store/Dynamo.scala
@@ -214,6 +214,14 @@ class Dynamo(db: DynamoDB, usersTable: String, keysTable: String, labelTable: St
     result.asScala.toList.map(fromKongItem).headOption
   }
 
+  def getKeyWithValueV2(keyValue: String): Option[KongKey] = {
+    val querySpec = new QuerySpec()
+      .withKeyConditionExpression("keyValue = :keyValue")
+      .withValueMap(new ValueMap().withString(":keyValue", keyValue))
+    val result = KongTable.getIndex("keyValue-index-all-attributes").query(querySpec)
+    result.asScala.toList.map(fromKongItem).headOption
+  }
+
   def getKeysWithUserId(bonoboId: String): List[KongKey] = {
     val keyQuery = new QuerySpec()
       .withKeyConditionExpression("hashkey = :h")

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,14 @@ lazy val root = (project in file("."))
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
 
+lazy val developerApiKeys = (project in file("dev/developer-api-keys"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.scopt" %% "scopt" % "4.0.0-RC2"
+    )
+  )
+  .dependsOn(root)
+
 libraryDependencies ++= Seq(
   ws,
   filters,

--- a/dev/developer-api-keys/README.md
+++ b/dev/developer-api-keys/README.md
@@ -1,0 +1,18 @@
+# Developer API keys
+
+Script to understand which API keys currently being used are issued under Developer tier. This is relevant since Gibbons 
+deletes keys in the Developer tier, so we want to eyeball the generated list for any that might be used in PROD.
+
+## API key usage file
+
+The script takes as an argument the location of a CSV file with API key usage. To generate this file:
+ElasticSearch SQL can be used to perform a count of requests by API key (see below). The query can be conveniently
+executed in the Dev Tools section of Kibana. The results can then be exported to a temporary local file for use by the 
+script, but NOT checked into version control!
+
+```
+GET _sql?format=csv
+{
+  "query": "SELECT \"queryparams.api-key\" as api_key, COUNT(1) AS request_count FROM \"logstash-capi-*\" WHERE \"@timestamp\" > NOW() - INTERVAL 1 MINUTE AND stage = 'PROD-AARDVARK' AND stack != 'content-api-preview' AND type = 'access' AND app = 'concierge' AND \"queryparams.api-key\" IS NOT NULL GROUP BY 1 ORDER BY request_count DESC"
+}
+```

--- a/dev/developer-api-keys/src/main/scala/com/gu/bonobo/Main.scala
+++ b/dev/developer-api-keys/src/main/scala/com/gu/bonobo/Main.scala
@@ -1,0 +1,126 @@
+package com.gu.bonobo
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import models.Tier
+import scopt.OParser
+import store.Dynamo
+import util.AWSConstants
+
+import scala.io.Source
+import scala.util.Try
+
+case class Config(
+   usersTable: String,
+   keysTable: String,
+   labelsTable: String,
+   apiKeyUsageFile: String,
+   usageCount: Int
+)
+
+object Config {
+
+  val code: Config = Config(
+    usersTable = "bonobo-CODE-users",
+    keysTable = "bonobo-CODE-keys",
+    labelsTable = "bonobo-CODE-labels",
+    apiKeyUsageFile = "",
+    usageCount = 1
+  )
+
+  private val builder = OParser.builder[Config]
+
+  private val parser = {
+    import builder._
+    OParser.sequence(
+      head(
+        "Given a csv file with API key usage,\n",
+        "query the Bonobo keys database to understand which of these are in the Developer tier.\n",
+        "This is relevant since Gibbons deletes keys in the Developer tier,\n",
+        "so we want to eyeball the generated list for any that might be used in PROD."
+      ),
+      programName("run"),
+      help("help"),
+      opt[String]("users")
+        .action((usersTable, config) => config.copy(usersTable = usersTable)),
+      opt[String]("keys")
+        .action((keysTable, config) => config.copy(keysTable = keysTable)),
+      opt[String]("labels")
+        .action((labelsTable, config) => config.copy(labelsTable = labelsTable)),
+      opt[String]("api-key-usage")
+        .text("see README on how this file can be generated; never check this file into version control")
+        .action((apiKeyUsageFile, config) => config.copy(apiKeyUsageFile = apiKeyUsageFile))
+        .required(),
+      opt[Int]("usage-count")
+        .text("not interested in API keys with usage count < this number")
+        .action((usageCount, config) => config.copy(usageCount = usageCount))
+    )
+  }
+
+  def parse(args: Seq[String]): Config = {
+    OParser.parse(parser, args, Config.code).getOrElse(throw new RuntimeException("invalid args"))
+  }
+}
+
+object ApiKeyUsage {
+
+  case class Item(apiKey: String, count: Int)
+
+  def fromFile(filename: String): List[Item] = {
+    val source = Source.fromFile(filename)
+    try {
+      source.getLines.flatMap { line =>
+        Try {
+          val fields = line.split(",")
+          Item(fields(0), fields(1).toInt)
+        }.toOption
+      }.toList
+    } finally {
+      source.close()
+    }
+  }
+}
+
+case class HighRiskApiKey(email: String, productName: String, usageCount: Int)
+
+object Main extends App {
+
+  val config = Config.parse(args)
+
+  val dynamoDbClient = AmazonDynamoDBClientBuilder.standard()
+    .withCredentials(AWSConstants.CredentialsProvider)
+    .withRegion(Regions.EU_WEST_1)
+    .build()
+
+  val dynamoDb = new DynamoDB(dynamoDbClient)
+
+  val dynamo = new Dynamo(
+    new DynamoDB(dynamoDbClient),
+    usersTable = config.usersTable,
+    keysTable = config.keysTable,
+    labelTable = config.labelsTable
+  )
+
+  val highRiskApiKeys = ApiKeyUsage.fromFile(config.apiKeyUsageFile)
+    .foldLeft(List.empty[HighRiskApiKey]) { case (keys, usage) =>
+      println("processing API key")
+      val highRiskApiKey =
+        for {
+          kongKey <- dynamo.getKeyWithValue(usage.apiKey) if usage.count >= config.usageCount
+          user <- dynamo.getUserWithId(kongKey.bonoboId) if kongKey.tier == Tier.Developer
+        } yield {
+          HighRiskApiKey(user.email, kongKey.productName, usage.count)
+        }
+      highRiskApiKey.fold(keys)(_ :: keys)
+    }
+
+  for {
+    apiKey <- highRiskApiKeys
+  } yield {
+    println(s"${apiKey.email}, ${apiKey.productName}, ${apiKey.usageCount}")
+  }
+
+  dynamoDb.shutdown()
+  dynamoDbClient.shutdown()
+}

--- a/dev/developer-api-keys/src/main/scala/com/gu/bonobo/Main.scala
+++ b/dev/developer-api-keys/src/main/scala/com/gu/bonobo/Main.scala
@@ -107,7 +107,7 @@ object Main extends App {
       println("processing API key")
       val highRiskApiKey =
         for {
-          kongKey <- dynamo.getKeyWithValue(usage.apiKey) if usage.count >= config.usageCount
+          kongKey <- dynamo.getKeyWithValueV2(usage.apiKey) if usage.count >= config.usageCount
           user <- dynamo.getUserWithId(kongKey.bonoboId) if kongKey.tier == Tier.Developer
         } yield {
           HighRiskApiKey(user.email, kongKey.productName, usage.count)


### PR DESCRIPTION
## What does this change?
See newly added README for context.

Regarding the new index `keyValue-index-all-attributes` that was created. This was due to the method `getKeyWithValue()` performing a full table scan. In a subsequent PR, I will update the application to use this new index. Note I haven't cloud formed the new index since the resources associated with the Bonobo cloudformation template(s) have drifted; I see resolving this as a separate task. 