### PR TITLE
Key creation dates fix

### DIFF
--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -46,6 +46,8 @@ object Kong {
   }
 
   def consumerCreationResponseFor(consumer: KongCreateConsumerResponse, key: String): ConsumerCreationResult = {
+    // Kong API 0.14 (and higher) renders data as 10 digit seconds since 1970.
+    // Previous Kong API versions (such as 0.9) used a 14 digit milliseconds since 1970 format
     ConsumerCreationResult(consumer.id, new DateTime(new Instant(consumer.created_at * 1000), DateTimeZone.UTC), key)
   }
 }

--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -73,10 +73,14 @@ class KongClient(ws: WSClient, serverUrl: String, apiName: String) extends Kong 
 
   def createConsumerAndKey(tier: Tier, rateLimit: RateLimits, key: Option[String]): Future[ConsumerCreationResult] = {
     for {
-      consumer <- createConsumer(tier)
-      _ <- setRateLimit(consumer.id, rateLimit)
-      key <- createKey(consumer.id, key)
-    } yield ConsumerCreationResult(consumer.id, new DateTime(consumer.created_at), key)
+      createConsumerResponse <- createConsumer(tier)
+      _ <- setRateLimit(createConsumerResponse.id, rateLimit)
+      key <- createKey(createConsumerResponse.id, key)
+    } yield consumerCreationResponseFor(createConsumerResponse, key)
+  }
+
+  protected def consumerCreationResponseFor(consumer: KongCreateConsumerResponse, key: String): ConsumerCreationResult = {
+    ConsumerCreationResult(consumer.id, new DateTime(consumer.created_at), key)
   }
 
   private def createConsumer(tier: Tier): Future[KongCreateConsumerResponse] = {

--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -1,14 +1,12 @@
 package kong
 
-import java.util.UUID
-
 import models._
-import org.joda.time.DateTime
-
+import org.joda.time.{DateTime, DateTimeZone, Instant}
+import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws._
-import play.api.Logger
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -48,7 +46,7 @@ object Kong {
   }
 
   def consumerCreationResponseFor(consumer: KongCreateConsumerResponse, key: String): ConsumerCreationResult = {
-    ConsumerCreationResult(consumer.id, new DateTime(consumer.created_at), key)
+    ConsumerCreationResult(consumer.id, new DateTime(new Instant(consumer.created_at * 1000), DateTimeZone.UTC), key)
   }
 }
 

--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -1,7 +1,7 @@
 package kong
 
 import models._
-import org.joda.time.{DateTime, DateTimeZone, Instant}
+import org.joda.time.{ DateTime, DateTimeZone, Instant }
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws._

--- a/app/kong/Kong.scala
+++ b/app/kong/Kong.scala
@@ -46,6 +46,10 @@ object Kong {
   object KongPluginConfig {
     implicit val pluginsRead = Json.reads[KongPluginConfig]
   }
+
+  def consumerCreationResponseFor(consumer: KongCreateConsumerResponse, key: String): ConsumerCreationResult = {
+    ConsumerCreationResult(consumer.id, new DateTime(consumer.created_at), key)
+  }
 }
 
 trait Kong {
@@ -77,10 +81,6 @@ class KongClient(ws: WSClient, serverUrl: String, apiName: String) extends Kong 
       _ <- setRateLimit(createConsumerResponse.id, rateLimit)
       key <- createKey(createConsumerResponse.id, key)
     } yield consumerCreationResponseFor(createConsumerResponse, key)
-  }
-
-  protected def consumerCreationResponseFor(consumer: KongCreateConsumerResponse, key: String): ConsumerCreationResult = {
-    ConsumerCreationResult(consumer.id, new DateTime(consumer.created_at), key)
   }
 
   private def createConsumer(tier: Tier): Future[KongCreateConsumerResponse] = {

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "it,test",
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "com.beachape" %% "enumeratum" % "1.5.13",
-  "com.beachape" %% "enumeratum-play-json" % "1.5.16"
+  "com.beachape" %% "enumeratum-play-json" % "1.5.16",
+  "joda-time" % "joda-time" % "2.10.9"
 )
 
 enablePlugins(RiffRaffArtifact, JavaAppPackaging)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,7 +1,7 @@
 # This is the main configuration file for the application.
 # ~~~~~
 kong.apiName = "internal"
-kong.apiAddress = "http://192.168.99.100:8001"
+kong.apiAddress = "http://localhost:8001"
 
 # The dynamo tables for users, keys and labels
 aws.dynamo.usersTableName = "bonobo-CODE-users"

--- a/scripts/backfill-created-dates.py
+++ b/scripts/backfill-created-dates.py
@@ -1,5 +1,6 @@
 import boto3
 from boto3.dynamodb.conditions import Attr
+from decimal import Decimal
 
 print(boto3.session.Session().available_profiles)
 
@@ -18,17 +19,30 @@ print(table)
 cutoffDate = 1000000000000
 
 response = table.scan(
-    Limit=25,
-    FilterExpression=Attr('createdAt').lt(cutoffDate)
+    Limit=23,
+    FilterExpression=Attr('createdAt').lt(cutoffDate),
 )
 
 print(f"Found {response['Count']} / scanned {response['ScannedCount']}")
 
 items = response['Items']
 for item in items:
-	keyValue = item['keyValue']
-	createdAt = item['createdAt']
-	if createdAt < cutoffDate:
-	    updatedCreatedAt = createdAt * 1000
-	    print(f"Item {keyValue} has old createdAt {createdAt} and will updated to {updatedCreatedAt}")
-        // TODO apply update
+    keyValue = item['keyValue']
+    createdAt = item['createdAt']
+    if createdAt < cutoffDate:
+        updatedCreatedAt = createdAt * 1000
+        print(f"Item {keyValue} has old createdAt {createdAt} and will updated to {updatedCreatedAt}")
+        rangeKey = item['rangekey']
+        updateResponse = table.update_item(
+            Key={
+                'hashkey': "hashkey",
+                'rangekey': rangeKey,
+            },
+            UpdateExpression="set createdAt=:c",
+            ExpressionAttributeValues={
+            ':c': Decimal(updatedCreatedAt)
+            },
+            ReturnValues="UPDATED_NEW"
+        )
+        print(updateResponse)
+

--- a/scripts/backfill-created-dates.py
+++ b/scripts/backfill-created-dates.py
@@ -19,7 +19,7 @@ print(table)
 cutoffDate = 1000000000000
 
 response = table.scan(
-    Limit=23,
+    Limit=100,
     FilterExpression=Attr('createdAt').lt(cutoffDate),
 )
 

--- a/scripts/backfill-created-dates.py
+++ b/scripts/backfill-created-dates.py
@@ -1,0 +1,34 @@
+import boto3
+from boto3.dynamodb.conditions import Attr
+
+print(boto3.session.Session().available_profiles)
+
+capi = boto3.session.Session(profile_name='capi', region_name='eu-west-1')
+
+print(capi)
+
+# Get the service resource.
+dynamodb = capi.resource('dynamodb')
+
+
+table = dynamodb.Table('bonobo-CODE-keys')
+print(table)
+
+# A sensible epoch mills datetime will not be less than this
+cutoffDate = 1000000000000
+
+response = table.scan(
+    Limit=25,
+    FilterExpression=Attr('createdAt').lt(cutoffDate)
+)
+
+print(f"Found {response['Count']} / scanned {response['ScannedCount']}")
+
+items = response['Items']
+for item in items:
+	keyValue = item['keyValue']
+	createdAt = item['createdAt']
+	if createdAt < cutoffDate:
+	    updatedCreatedAt = createdAt * 1000
+	    print(f"Item {keyValue} has old createdAt {createdAt} and will updated to {updatedCreatedAt}")
+        // TODO apply update

--- a/scripts/backfill-created-dates.py
+++ b/scripts/backfill-created-dates.py
@@ -1,6 +1,7 @@
 import boto3
 from boto3.dynamodb.conditions import Attr
 from decimal import Decimal
+import time
 
 print(boto3.session.Session().available_profiles)
 
@@ -45,4 +46,5 @@ for item in items:
             ReturnValues="UPDATED_NEW"
         )
         print(updateResponse)
+        time.sleep(0.5)
 

--- a/test/kong/KongSpec.scala
+++ b/test/kong/KongSpec.scala
@@ -1,0 +1,24 @@
+package kong
+
+import kong.Kong.KongCreateConsumerResponse
+import org.joda.time.format.ISODateTimeFormat
+import org.scalatest.{FlatSpec, Matchers}
+
+class KongSpec extends FlatSpec with Matchers {
+
+  "ConsumerClientResponse" should "be correctly constructed from Kong response" in {
+
+    val createConsumerResponse = KongCreateConsumerResponse(
+      id = "some-new-consumer-id",
+      // Kong API 0.14 (and higher) renders data as 10 digit seconds since 1970.
+      // Previous Kong API versions (such as 0.9) used a 14 digit milliseconds since 1970 format
+      created_at = 1422386534
+    )
+    val keyId = "some-new-key-id"
+
+    val result = Kong.consumerCreationResponseFor(createConsumerResponse, keyId)
+
+    assert(result.createdAt == ISODateTimeFormat.basicDateTimeNoMillis().parseDateTime("20150127T192214Z"))
+  }
+
+}

--- a/test/kong/KongSpec.scala
+++ b/test/kong/KongSpec.scala
@@ -18,7 +18,7 @@ class KongSpec extends FlatSpec with Matchers {
 
     val result = Kong.consumerCreationResponseFor(createConsumerResponse, keyId)
 
-    assert(result.createdAt == ISODateTimeFormat.basicDateTimeNoMillis().parseDateTime("20150127T192214Z"))
+    assert(result.createdAt.isEqual(ISODateTimeFormat.basicDateTimeNoMillis().parseDateTime("20150127T192214Z")))
   }
 
 }

--- a/test/kong/KongSpec.scala
+++ b/test/kong/KongSpec.scala
@@ -2,7 +2,7 @@ package kong
 
 import kong.Kong.KongCreateConsumerResponse
 import org.joda.time.format.ISODateTimeFormat
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{ FlatSpec, Matchers }
 
 class KongSpec extends FlatSpec with Matchers {
 
@@ -12,8 +12,7 @@ class KongSpec extends FlatSpec with Matchers {
       id = "some-new-consumer-id",
       // Kong API 0.14 (and higher) renders data as 10 digit seconds since 1970.
       // Previous Kong API versions (such as 0.9) used a 14 digit milliseconds since 1970 format
-      created_at = 1422386534
-    )
+      created_at = 1422386534)
     val keyId = "some-new-key-id"
 
     val result = Kong.consumerCreationResponseFor(createConsumerResponse, keyId)


### PR DESCRIPTION
## What does this change?

Fixes incorrect 1970 creation dates for newly created keys.

Kong API 0.14 and high renders date times as epoch seconds. Older versions of the Kong API seem to have used milliseconds.

<img width="184" alt="Screenshot 2021-01-28 at 16 12 34" src="https://user-images.githubusercontent.com/150238/106265199-97305480-621e-11eb-9241-ac593b13bd62.png">


An old version of Kong (0.9) returning milliseconds. 
We once used Kong 0.5 and bonobo was probably coded against that.

<img width="520" alt="Screenshot 2021-01-28 at 19 58 59" src="https://user-images.githubusercontent.com/150238/106265213-9c8d9f00-621e-11eb-8f08-f1e95d42f5b1.png">


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
