### PR TITLE
Deploy bonobo with a bionic Java 8 base image

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
     type: ami-cloudformation-parameter
     parameters:
       amiTags:
-        Recipe: ubuntu-xenial-capi
+        Recipe: ubuntu-bionic-capi
         AmigoStage: PROD
       amiEncrypted: true
       cloudFormationStackName: bonobo


### PR DESCRIPTION
## What does this change?

Deploy with `ubuntu-bionic-capi` base image which has the same java8 and and logstash roles as the old xenial image.

<img width="589" alt="Screenshot 2021-03-03 at 13 04 51" src="https://user-images.githubusercontent.com/150238/109810380-5fec0380-7c21-11eb-84db-32d0dedaa7ef.png">

## How to test

Bonoho code still works.
Logstash still stashing
instance logstash logs not showing errors.


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
