### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ We recommend running them in Docker containers. See instructions below on how to
 
 ## To run locally using Docker
 
-Ensure Docker Desktop is running.
+- Ensure Docker Desktop is running.
+- Ensure you have Content API developer credentials [from Janus]
+- Ensure you are compiling and running the application using Java 8. (It is best to run the application in an sbt shell that uses JDK 1.8)
 
 2. Run the `configure-docker.sh` script:
 
@@ -34,6 +36,9 @@ Ensure Docker Desktop is running.
   Then it will add an API in Kong with the key-auth plugin enabled.
 
 4. Edit `conf/application.conf` to point `kong.apiAddress` at your Kong cluster (in this example: `http://192.168.99.100:8001`). In the same file you should configure `aws.dynamo.usersTableName`, `aws.dynamo.keysTableName` and `aws.dynamo.labelsTableName` to point to the DynamoDB tables you are going to use.
+You do not need to change the play.http.secret.key to run the app locally.
+   
+Note: In CODE and PROD the app does NOT use the configurations in conf/application.conf. Instead, it pulls its configurations from a bonobo.conf file which you can find on the live instance(s).
 
 5. Then start the Play app:
 
@@ -62,3 +67,5 @@ If you change this anchor, you should change the corresponding Bonobo source cod
 --->
 Keys issued under the `Developer` tier can be periodically deleted by [Gibbons](https://github.com/guardian/gibbons).
 Therefore, if an API key is intended to be used by a service, it should __not__ be issued under the `Developer` tier.
+
+

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ We recommend running them in Docker containers. See instructions below on how to
 ## To run locally using Docker
 
 - Ensure Docker Desktop is running.
-- Ensure you have Content API developer credentials [from Janus]
-- Ensure you are compiling and running the application using Java 8. (It is best to run the application in an sbt shell that uses JDK 1.8)
+- Ensure you have Content API developer credentials (from Janus)
+- Ensure you're compiling and running the application using Java 8. (It is best to run the application in an sbt shell that uses JDK 1.8)
 
 2. Run the `configure-docker.sh` script:
 
@@ -38,7 +38,7 @@ We recommend running them in Docker containers. See instructions below on how to
 4. Edit `conf/application.conf` to point `kong.apiAddress` at your Kong cluster (in this example: `http://192.168.99.100:8001`). In the same file you should configure `aws.dynamo.usersTableName`, `aws.dynamo.keysTableName` and `aws.dynamo.labelsTableName` to point to the DynamoDB tables you are going to use.
 You do not need to change the play.http.secret.key to run the app locally.
    
-Note: In CODE and PROD the app does NOT use the configurations in conf/application.conf. Instead, it pulls its configurations from a bonobo.conf file which you can find on the live instance(s).
+Note: In CODE and PROD the app does NOT use the configurations in the `conf/application.conf` file. Instead, it pulls its configurations from a `bonobo.conf` file which you can find on the live instance(s).
 
 5. Then start the Play app:
 


### PR DESCRIPTION
## What does this change?
Updates readme to make it clearer how to run Bonobo locally and where Live Bonobo pulls its configurations from.

## How to test
Clone repo and try running bonobo locally following the steps in the readme file. 
