### PR TITLE
Rollback and reintroduce extended at field

### DIFF
--- a/app/views/renderKeysTable.scala.html
+++ b/app/views/renderKeysTable.scala.html
@@ -1,8 +1,4 @@
-@import org.joda.time.DateTime
-
 @(keys: List[BonoboInfo], lastDirection: String, hasNext: Boolean)
-
-
 
 <div class="col-md-12">
     <table class="table table-responsive table-striped table-hover">
@@ -15,8 +11,7 @@
                 <th>Product</th>
                 <th>Tier</th>
                 <th>Status</th>
-                <th>Created</th>
-                <th>Extended</th>
+                <th>Created at</th>
             </tr>
         </thead>
         <tbody>
@@ -30,12 +25,6 @@
                     <td>@key.kongKey.tier.friendlyName</td>
                     <td>@key.kongKey.status</td>
                     <td>@key.kongKey.createdAt.toString("dd-MM-yyyy hh:mma")</td>
-                    <td>
-                    @if(key.bonoboUser.additionalInfo.extendedAt.isDefined) {
-                        @{new DateTime(key.bonoboUser.additionalInfo.extendedAt.get).toString("dd-MM-yyyy hh:mma")}
-                    }
-                    </td>
-
                 </tr>
             }
         </tbody>

--- a/app/views/renderKeysTable.scala.html
+++ b/app/views/renderKeysTable.scala.html
@@ -1,3 +1,4 @@
+@import org.joda.time.DateTime
 @(keys: List[BonoboInfo], lastDirection: String, hasNext: Boolean)
 
 <div class="col-md-12">
@@ -11,7 +12,8 @@
                 <th>Product</th>
                 <th>Tier</th>
                 <th>Status</th>
-                <th>Created at</th>
+                <th>Created</th>
+                <th>Extended</th>
             </tr>
         </thead>
         <tbody>
@@ -25,6 +27,11 @@
                     <td>@key.kongKey.tier.friendlyName</td>
                     <td>@key.kongKey.status</td>
                     <td>@key.kongKey.createdAt.toString("dd-MM-yyyy hh:mma")</td>
+                    <td>
+                    @if(key.bonoboUser.additionalInfo.extendedAt.isDefined) {
+                        @{new DateTime(key.bonoboUser.additionalInfo.extendedAt.get).toString("dd-MM-yyyy hh:mma")}
+                    }
+                    </td>
                 </tr>
             }
         </tbody>


### PR DESCRIPTION
## What does this change?
This reverts commit 9200b1716b0befb322c58fd854a005fe4a42c33c (pushed directly to master by mistake) and reintroduces the changes to follow best practice.

## What was done?
A new field has been added to the All Keys view page in bonobo to display the key's extendedAt field if it exists.

## How to test
Run bonobo locally and point the application.conf file to the PROD dynamoDB tables (the extendedAt field does not exist in CODE).
Check All Keys view page for the extendedAt field or search for a specific user that you know has an extendedAt date and look for the date being displayed in correct format.
(You can also just look at Bonobo PROD as the change is already reflected there)

## How can we measure success?
Field should display correct date in correct format if it exists and should handle null values gracefully by displaying nothing.

## Have we considered potential risks?
This is a low-risk change.

## Images
Example of what the field looks like:
![Screenshot 2021-07-07 at 11 10 59](https://user-images.githubusercontent.com/74187452/124763337-bfd61c00-df2b-11eb-9c3a-b05cc916ec19.png)

